### PR TITLE
Read service availability from a different branch

### DIFF
--- a/datasetUtils/checkForServiceAvailability.go
+++ b/datasetUtils/checkForServiceAvailability.go
@@ -26,7 +26,7 @@ type ServiceAvailability struct {
 	Qa         OverallAvailability
 }
 
-var GitHubMainLocation = "https://raw.githubusercontent.com/paulscherrerinstitute/scicat-cli/main"
+var GitHubMainLocation = "https://raw.githubusercontent.com/paulscherrerinstitute/scicat-cli/service-availability"
 
 // CheckForServiceAvailability checks the availability of the dataset ingestor service.
 // It fetches a YAML file from GitHubMainLocation, parses it, and logs the service availability status.


### PR DESCRIPTION
Change GitHubMainLocation to new branch. Closes #27 
The branch should not be deleted. @minottic, can you protect the branch from the settings? The setting is not open to me. It is under the branch protection rule.