### PR TITLE
set goreleaser to prerelease mode if the version in the tag is non-final

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,3 +61,6 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+release:
+  prerelease: auto


### PR DESCRIPTION
With this change, goreleaser will use a pre-release method if the tag contains "-alphax", "-betax" or other prerelease format.