### PR TITLE
add common flags that are shared between commands (user, token, config)

### DIFF
--- a/cmd/commands/args_test.go
+++ b/cmd/commands/args_test.go
@@ -49,7 +49,7 @@ func TestArgs(t *testing.T) {
 			//flag.CommandLine = flag.NewFlagSet(test.name, flag.ExitOnError)
 			datasetUtils.TestArgs = func(args []interface{}) {
 				passing := true
-				for i, _ := range test.expectedArgs {
+				for i := range test.expectedArgs {
 					if test.expectedArgs[i] != args[i] {
 						t.Logf("'%v' is not correct, expected: '%s'", args[i], test.expectedArgs[i])
 						passing = false

--- a/cmd/commands/datasetArchiver.go
+++ b/cmd/commands/datasetArchiver.go
@@ -139,7 +139,6 @@ func init() {
 	datasetArchiverCmd.Flags().Bool("localenv", false, "Use local environment (local) instead or production")
 	datasetArchiverCmd.Flags().Bool("devenv", false, "Use development environment instead or production")
 	datasetArchiverCmd.Flags().Bool("noninteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
-	datasetArchiverCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	datasetArchiverCmd.MarkFlagsMutuallyExclusive("testenv", "localenv", "devenv")
 }

--- a/cmd/commands/datasetArchiver.go
+++ b/cmd/commands/datasetArchiver.go
@@ -134,8 +134,6 @@ For further help see "` + MANUAL + `"`,
 func init() {
 	rootCmd.AddCommand(datasetArchiverCmd)
 
-	datasetArchiverCmd.Flags().String("user", "", "Defines optional username and password")
-	datasetArchiverCmd.Flags().String("token", "", "Defines optional API token instead of username:password")
 	datasetArchiverCmd.Flags().Int("tapecopies", 1, "Number of tapecopies to be used for archiving")
 	datasetArchiverCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead or production")
 	datasetArchiverCmd.Flags().Bool("localenv", false, "Use local environment (local) instead or production")

--- a/cmd/commands/datasetCleaner.go
+++ b/cmd/commands/datasetCleaner.go
@@ -118,8 +118,6 @@ func init() {
 	datasetCleanerCmd.Flags().Bool("nonInteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
 	datasetCleanerCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
 	datasetCleanerCmd.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")
-	datasetCleanerCmd.Flags().String("user", "", "Defines optional username:password string")
-	datasetCleanerCmd.Flags().String("token", "", "Defines optional API token instead of username:password")
 	datasetCleanerCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	datasetCleanerCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")

--- a/cmd/commands/datasetCleaner.go
+++ b/cmd/commands/datasetCleaner.go
@@ -118,7 +118,6 @@ func init() {
 	datasetCleanerCmd.Flags().Bool("nonInteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
 	datasetCleanerCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
 	datasetCleanerCmd.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")
-	datasetCleanerCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	datasetCleanerCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
 }

--- a/cmd/commands/datasetGetProposal.go
+++ b/cmd/commands/datasetGetProposal.go
@@ -104,8 +104,6 @@ For further help see "` + MANUAL + `"`,
 func init() {
 	rootCmd.AddCommand(datasetGetProposalCmd)
 
-	datasetGetProposalCmd.Flags().String("user", "", "Defines optional username and password")
-	datasetGetProposalCmd.Flags().String("token", "", "Defines optional API token instead of username:password")
 	datasetGetProposalCmd.Flags().String("field", "", "Defines optional field name , whose value should be returned instead of full information")
 	datasetGetProposalCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead or production")
 	datasetGetProposalCmd.Flags().Bool("devenv", false, "Use development environment instead or production")

--- a/cmd/commands/datasetGetProposal.go
+++ b/cmd/commands/datasetGetProposal.go
@@ -107,7 +107,6 @@ func init() {
 	datasetGetProposalCmd.Flags().String("field", "", "Defines optional field name , whose value should be returned instead of full information")
 	datasetGetProposalCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead or production")
 	datasetGetProposalCmd.Flags().Bool("devenv", false, "Use development environment instead or production")
-	datasetGetProposalCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	datasetGetProposalCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
 }

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -400,7 +400,6 @@ func init() {
 	datasetIngestorCmd.Flags().Bool("allowexistingsource", false, "Defines if existing sourceFolders can be reused")
 	datasetIngestorCmd.Flags().String("addattachment", "", "Filename of image to attach (single dataset case only)")
 	datasetIngestorCmd.Flags().String("addcaption", "", "Optional caption to be stored with attachment (single dataset case only)")
-	datasetIngestorCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	datasetIngestorCmd.MarkFlagsMutuallyExclusive("testenv", "devenv", "localenv", "tunnelenv")
 }

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -392,8 +392,6 @@ func init() {
 	datasetIngestorCmd.Flags().Bool("localenv", false, "Use local environment instead of production environment (developers only)")
 	datasetIngestorCmd.Flags().Bool("tunnelenv", false, "Use tunneled API server at port 5443 to access development instance (developers only)")
 	datasetIngestorCmd.Flags().Bool("noninteractive", false, "If set no questions will be asked and the default settings for all undefined flags will be assumed")
-	datasetIngestorCmd.Flags().String("user", "", "Defines optional username:password string. This can be used both for access to the data catalog API and for access to the intermediate storage server for the decentral use case")
-	datasetIngestorCmd.Flags().String("token", "", "Defines API token for access to the data catalog API. It is now mandatory for normal user accounts, but optional for functional accounts. It takes precedence over username/pw.")
 	datasetIngestorCmd.Flags().Bool("copy", false, "Defines if files should be copied from your local system to a central server before ingest (i.e. your data is not centrally available and therefore needs to be copied ='decentral' case). copyFlag has higher priority than nocopyFlag. If neither flag is defined the tool will try to make the best guess.")
 	datasetIngestorCmd.Flags().Bool("nocopy", false, "Defines if files should *not* be copied from your local system to a central server before ingest (i.e. your data is centrally available and therefore does not need to be copied ='central' case).")
 	datasetIngestorCmd.Flags().Int("tapecopies", 0, "Number of tapecopies to be used for archiving")

--- a/cmd/commands/datasetPublishData.go
+++ b/cmd/commands/datasetPublishData.go
@@ -337,7 +337,6 @@ func init() {
 	// datasetPublishDataCmd.Flags().String("ownergroup", "", "Defines to publish only datasets of the specified ownerGroup")
 	datasetPublishDataCmd.Flags().Bool("testenv", false, "Use test environment (qa) (default is to use production system)")
 	datasetPublishDataCmd.Flags().Bool("devenv", false, "Use development environment (default is to use production system)")
-	datasetPublishDataCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	datasetPublishDataCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
 }

--- a/cmd/commands/datasetPublishData.go
+++ b/cmd/commands/datasetPublishData.go
@@ -335,8 +335,6 @@ func init() {
 	datasetPublishDataCmd.Flags().String("publisheddata", "", "Defines to publish data froma given publishedData document ID")
 	// datasetPublishDataCmd.Flags().String("dataset", "", "Defines single datasetId to publish")
 	// datasetPublishDataCmd.Flags().String("ownergroup", "", "Defines to publish only datasets of the specified ownerGroup")
-	datasetPublishDataCmd.Flags().String("user", "", "Defines optional username:password string")
-	datasetPublishDataCmd.Flags().String("token", "", "Defines optional API token instead of username:password")
 	datasetPublishDataCmd.Flags().Bool("testenv", false, "Use test environment (qa) (default is to use production system)")
 	datasetPublishDataCmd.Flags().Bool("devenv", false, "Use development environment (default is to use production system)")
 	datasetPublishDataCmd.Flags().Bool("version", false, "Show version number and exit")

--- a/cmd/commands/datasetPublishDataRetrieve.go
+++ b/cmd/commands/datasetPublishDataRetrieve.go
@@ -122,7 +122,6 @@ func init() {
 	datasetPublishDataRetrieveCmd.Flags().String("publisheddata", "", "Defines to publish data from a given publishedData document ID")
 	datasetPublishDataRetrieveCmd.Flags().Bool("testenv", false, "Use test environment (qa) (default is to use production system)")
 	datasetPublishDataRetrieveCmd.Flags().Bool("devenv", false, "Use development environment (default is to use production system)")
-	datasetPublishDataRetrieveCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	datasetPublishDataRetrieveCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
 }

--- a/cmd/commands/datasetPublishDataRetrieve.go
+++ b/cmd/commands/datasetPublishDataRetrieve.go
@@ -120,8 +120,6 @@ func init() {
 
 	datasetPublishDataRetrieveCmd.Flags().Bool("retrieve", false, "Defines if this command is meant to actually retrieve data (default: retrieve actions are only displayed)")
 	datasetPublishDataRetrieveCmd.Flags().String("publisheddata", "", "Defines to publish data from a given publishedData document ID")
-	datasetPublishDataRetrieveCmd.Flags().String("user", "", "Defines optional username:password string")
-	datasetPublishDataRetrieveCmd.Flags().String("token", "", "Defines optional API token instead of username:password")
 	datasetPublishDataRetrieveCmd.Flags().Bool("testenv", false, "Use test environment (qa) (default is to use production system)")
 	datasetPublishDataRetrieveCmd.Flags().Bool("devenv", false, "Use development environment (default is to use production system)")
 	datasetPublishDataRetrieveCmd.Flags().Bool("version", false, "Show version number and exit")

--- a/cmd/commands/datasetRetriever.go
+++ b/cmd/commands/datasetRetriever.go
@@ -211,8 +211,6 @@ func init() {
 	rootCmd.AddCommand(datasetRetrieverCmd)
 
 	datasetRetrieverCmd.Flags().Bool("retrieve", false, "Defines if this command is meant to actually copy data to the local system (default nothing is done)")
-	datasetRetrieverCmd.Flags().String("user", "", "Defines optional username and password (default is to prompt for username and password)")
-	datasetRetrieverCmd.Flags().String("token", "", "Defines optional API token instead of username:password")
 	datasetRetrieverCmd.Flags().Bool("nochksum", false, "Switch off chksum verification step (default checksum tests are done)")
 	datasetRetrieverCmd.Flags().String("dataset", "", "Defines single dataset to retrieve (default all available datasets)")
 	datasetRetrieverCmd.Flags().String("ownergroup", "", "Defines to fetch only datasets of the specified ownerGroup (default is to fetch all available datasets)")

--- a/cmd/commands/datasetRetriever.go
+++ b/cmd/commands/datasetRetriever.go
@@ -216,7 +216,6 @@ func init() {
 	datasetRetrieverCmd.Flags().String("ownergroup", "", "Defines to fetch only datasets of the specified ownerGroup (default is to fetch all available datasets)")
 	datasetRetrieverCmd.Flags().Bool("testenv", false, "Use test environment (qa) (default is to use production system)")
 	datasetRetrieverCmd.Flags().Bool("devenv", false, "Use development environment (default is to use production system)")
-	datasetRetrieverCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	datasetRetrieverCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
 }

--- a/cmd/commands/flags_test.go
+++ b/cmd/commands/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/paulscherrerinstitute/scicat/datasetUtils"
+	"github.com/spf13/pflag"
 )
 
 func TestMainFlags(t *testing.T) {
@@ -379,6 +380,11 @@ func TestMainFlags(t *testing.T) {
 					t.Fail()
 				}
 			}
+
+			rootCmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+				flag.Value.Set(flag.DefValue)
+				flag.Changed = false
+			})
 
 			rootCmd.SetArgs(test.args)
 			Execute()

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -25,4 +25,8 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	rootCmd.PersistentFlags().StringP("user", "u", "", "Defines optional username:password string")
+	rootCmd.PersistentFlags().String("token", "", "Defines optional API token instead of username:password")
+	rootCmd.PersistentFlags().StringP("config", "c", "", "A path to a config file for connecting to SciCat and transfer services")
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -12,8 +13,15 @@ var rootCmd = &cobra.Command{
 	Long: `This library comprises a few subcommands for managing SciCat
 and datasets on it, as well as interacting with the archival system connected
 to it.`,
-	// uncomment the next line if there's a default action
-	// Run: func(cmd *cobra.Command, args []string) { },
+	Run: func(cmd *cobra.Command, args []string) {
+		version, _ := cmd.Flags().GetBool("version")
+		if version {
+			fmt.Printf("%s\n", VERSION)
+			return
+		}
+		fmt.Print("No action was specified.\n\n")
+		cmd.Help()
+	},
 }
 
 func Execute() {
@@ -29,4 +37,5 @@ func init() {
 	rootCmd.PersistentFlags().StringP("user", "u", "", "Defines optional username:password string")
 	rootCmd.PersistentFlags().String("token", "", "Defines optional API token instead of username:password")
 	rootCmd.PersistentFlags().StringP("config", "c", "", "A path to a config file for connecting to SciCat and transfer services")
+	rootCmd.PersistentFlags().BoolP("version", "v", false, "Show version")
 }

--- a/cmd/commands/waitForJobFinished.go
+++ b/cmd/commands/waitForJobFinished.go
@@ -168,8 +168,6 @@ var waitForJobFinishedCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(waitForJobFinishedCmd)
 
-	waitForJobFinishedCmd.Flags().String("user", "", "Defines optional username and password")
-	waitForJobFinishedCmd.Flags().String("token", "", "Defines optional API token instead of username:password")
 	waitForJobFinishedCmd.Flags().String("job", "", "Defines the job id to poll")
 	waitForJobFinishedCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead or production")
 	waitForJobFinishedCmd.Flags().Bool("devenv", false, "Use development environment instead or production")

--- a/cmd/commands/waitForJobFinished.go
+++ b/cmd/commands/waitForJobFinished.go
@@ -171,7 +171,6 @@ func init() {
 	waitForJobFinishedCmd.Flags().String("job", "", "Defines the job id to poll")
 	waitForJobFinishedCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead or production")
 	waitForJobFinishedCmd.Flags().Bool("devenv", false, "Use development environment instead or production")
-	waitForJobFinishedCmd.Flags().Bool("version", false, "Show version number and exit")
 
 	waitForJobFinishedCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
 }


### PR DESCRIPTION
This commit moves two flags (user and token) and adds a (for now unused) config flag as persistent flags to the root command. 

This means that the flags can be specified before or after the subcommand, and they don't have to be declared for each subcommand. The handling of them still happens in subcommands.