### PR TITLE
Refactor/check central data

### DIFF
--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -290,8 +290,11 @@ For Windows you need instead to specify -user username:password on the command l
 				// and unless copy flag defined via command line
 				if !copyFlag && !nocopyFlag { // NOTE this whole copyFlag, nocopyFlag ordeal makes no sense whatsoever
 					if !beamlineAccount {
-						err := datasetIngestor.CheckDataCentrallyAvailable(user["username"], RSYNCServer, datasetSourceFolder)
-						if err != nil {
+						sshErr, otherErr := datasetIngestor.CheckDataCentrallyAvailableSsh(user["username"], RSYNCServer, sourceFolder, os.Stdout)
+						if otherErr != nil {
+							log.Fatalf("CheckDataCentrallyAvailableSsh returned an error: %v\n", otherErr)
+						}
+						if sshErr != nil {
 							color.Set(color.FgYellow)
 							log.Printf("The source folder %v is not centrally available (decentral use case).\nThe data must first be copied to a rsync cache server.\n ", datasetSourceFolder)
 							color.Unset()

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -290,7 +290,7 @@ For Windows you need instead to specify -user username:password on the command l
 				// and unless copy flag defined via command line
 				if !copyFlag && !nocopyFlag { // NOTE this whole copyFlag, nocopyFlag ordeal makes no sense whatsoever
 					if !beamlineAccount {
-						sshErr, otherErr := datasetIngestor.CheckDataCentrallyAvailableSsh(user["username"], RSYNCServer, sourceFolder, os.Stdout)
+						sshErr, otherErr := datasetIngestor.CheckDataCentrallyAvailableSsh(user["username"], RSYNCServer, datasetSourceFolder, os.Stdout)
 						if otherErr != nil {
 							log.Fatalf("CheckDataCentrallyAvailableSsh returned an error: %v\n", otherErr)
 						}

--- a/datasetIngestor/checkDataCentrallyAvailable.go
+++ b/datasetIngestor/checkDataCentrallyAvailable.go
@@ -2,8 +2,6 @@ package datasetIngestor
 
 import (
 	"errors"
-	"log"
-	"os"
 	"os/exec"
 	"runtime"
 )
@@ -11,11 +9,14 @@ import (
 // execCommand is a variable that points to exec.Command, allowing it to be replaced in tests.
 var execCommand = exec.Command
 
-// CheckDataCentrallyAvailable checks if a specific directory (sourceFolder) is available on a remote server (ARCHIVEServer)
+// CheckDataCentrallyAvailableSsh checks if a specific directory (sourceFolder) is available on a remote server (ARCHIVEServer)
 // using the provided username for SSH connection. It returns an error if the directory is not available or if there's an issue with the SSH connection.
-func CheckDataCentrallyAvailable(username string, ARCHIVEServer string, sourceFolder string) (err error) {
+// Returned values:
+// - sshErr - the error returned by the ssh command
+// - err - other error that prevents the ssh command from being executed
+func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourceFolder string) (sshErr error, otherErr error) {
 	// NOTE why not use crypto/ssh ???
-	// NOTE is this even a reliable method for people outside PSI?
+	// NOTE even if the folder is there, not all files might be there!
 	var cmd *exec.Cmd
 
 	// Check the operating system
@@ -24,26 +25,26 @@ func CheckDataCentrallyAvailable(username string, ARCHIVEServer string, sourceFo
 		// Check if ssh exists
 		_, err := exec.LookPath("ssh") // locate a program in the user's path
 		if err != nil {
-			log.Println("SSH is not installed. Please install OpenSSH client.")
-			return err
+			return nil, errors.New("no ssh implementation is available")
 		}
 
 		// Create a new exec.Command to run the SSH command. The command checks if the directory exists on the remote server.
 		// The "-q" option suppresses all warnings, "-l" specifies the login name on the remote server.
 		cmd = execCommand("ssh", "-q", "-l", username, ARCHIVEServer, "test", "-d", sourceFolder)
 	default:
-		log.Printf("%s is not supported.\n", os)
-		return errors.New("unsupported operating system")
+		//log.Printf("%s is not supported.\n", os)
+		return nil, errors.New("unsupported operating system")
 	}
 
 	// Redirect the command's standard error to the process's standard error.
 	// This means that any error messages from the command will be displayed in the terminal.
-	cmd.Stderr = os.Stderr
+	// Update: We don't want a library to output to the terminal.
+	// cmd.Stderr = os.Stderr
 
 	// Log the command that is being run for debugging purposes.
-	log.Printf("Running %v.\n", cmd.Args)
+	//log.Printf("Running %v.\n", cmd.Args)
 
 	// Run the command and return any error that occurs.
-	err = cmd.Run()
-	return err
+	sshErr = cmd.Run()
+	return sshErr, nil
 }

--- a/datasetIngestor/checkDataCentrallyAvailable.go
+++ b/datasetIngestor/checkDataCentrallyAvailable.go
@@ -2,6 +2,7 @@ package datasetIngestor
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 	"runtime"
@@ -34,7 +35,7 @@ func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourc
 		cmd = execCommand("ssh", "-q", "-l", username, ARCHIVEServer, "test", "-d", sourceFolder)
 	default:
 		//log.Printf("%s is not supported.\n", os)
-		return nil, errors.New("unsupported operating system")
+		return nil, fmt.Errorf("unsupported operating system: %s", os)
 	}
 
 	// Redirect the command's output to sshOutput var

--- a/datasetIngestor/checkDataCentrallyAvailable.go
+++ b/datasetIngestor/checkDataCentrallyAvailable.go
@@ -2,6 +2,7 @@ package datasetIngestor
 
 import (
 	"errors"
+	"io"
 	"os/exec"
 	"runtime"
 )
@@ -14,7 +15,7 @@ var execCommand = exec.Command
 // Returned values:
 // - sshErr - the error returned by the ssh command
 // - err - other error that prevents the ssh command from being executed
-func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourceFolder string) (sshErr error, otherErr error) {
+func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourceFolder string, sshOutput io.Writer) (sshErr error, otherErr error) {
 	// NOTE why not use crypto/ssh ???
 	// NOTE even if the folder is there, not all files might be there!
 	var cmd *exec.Cmd
@@ -36,10 +37,9 @@ func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourc
 		return nil, errors.New("unsupported operating system")
 	}
 
-	// Redirect the command's standard error to the process's standard error.
-	// This means that any error messages from the command will be displayed in the terminal.
-	// Update: We don't want a library to output to the terminal.
-	// cmd.Stderr = os.Stderr
+	// Redirect the command's output to sshOutput var
+	cmd.Stdout = sshOutput
+	cmd.Stderr = sshOutput
 
 	// Log the command that is being run for debugging purposes.
 	//log.Printf("Running %v.\n", cmd.Args)

--- a/datasetIngestor/checkDataCentrallyAvailable.go
+++ b/datasetIngestor/checkDataCentrallyAvailable.go
@@ -34,16 +34,12 @@ func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourc
 		// The "-q" option suppresses all warnings, "-l" specifies the login name on the remote server.
 		cmd = execCommand("ssh", "-q", "-l", username, ARCHIVEServer, "test", "-d", sourceFolder)
 	default:
-		//log.Printf("%s is not supported.\n", os)
 		return nil, fmt.Errorf("unsupported operating system: %s", os)
 	}
 
 	// Redirect the command's output to sshOutput var
 	cmd.Stdout = sshOutput
 	cmd.Stderr = sshOutput
-
-	// Log the command that is being run for debugging purposes.
-	//log.Printf("Running %v.\n", cmd.Args)
 
 	// Run the command and return any error that occurs.
 	sshErr = cmd.Run()

--- a/datasetIngestor/checkDataCentrallyAvailable_test.go
+++ b/datasetIngestor/checkDataCentrallyAvailable_test.go
@@ -90,7 +90,7 @@ func TestCheckDataCentrallyAvailable(t *testing.T) {
 		defer func() { execCommand = oldExecCommand }()
 
 		t.Run(tt.name, func(t *testing.T) {
-			sshErr, otherErr := CheckDataCentrallyAvailableSsh(tt.username, tt.archiveServer, tt.sourceFolder)
+			sshErr, otherErr := CheckDataCentrallyAvailableSsh(tt.username, tt.archiveServer, tt.sourceFolder, nil)
 			if otherErr != nil {
 				t.Errorf("other error encountered: %v", otherErr)
 			}

--- a/datasetIngestor/checkDataCentrallyAvailable_test.go
+++ b/datasetIngestor/checkDataCentrallyAvailable_test.go
@@ -90,12 +90,15 @@ func TestCheckDataCentrallyAvailable(t *testing.T) {
 		defer func() { execCommand = oldExecCommand }()
 
 		t.Run(tt.name, func(t *testing.T) {
-			err := CheckDataCentrallyAvailable(tt.username, tt.archiveServer, tt.sourceFolder)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CheckDataCentrallyAvailable() error = %v, wantErr %v", err, tt.wantErr)
+			sshErr, otherErr := CheckDataCentrallyAvailableSsh(tt.username, tt.archiveServer, tt.sourceFolder)
+			if otherErr != nil {
+				t.Errorf("other error encountered: %v", otherErr)
 			}
-			if err != nil && tt.wantErr && err.Error() != tt.errMsg {
-				t.Errorf("CheckDataCentrallyAvailable() errMsg = %v, wantErrMsg %v", err.Error(), tt.errMsg)
+			if (sshErr != nil) != tt.wantErr {
+				t.Errorf("CheckDataCentrallyAvailable() error = %v, wantErr %v", sshErr != nil, tt.wantErr)
+			}
+			if sshErr != nil && tt.wantErr && sshErr.Error() != tt.errMsg {
+				t.Errorf("CheckDataCentrallyAvailable() errMsg = %v, wantErrMsg %v", sshErr.Error(), tt.errMsg)
 			}
 		})
 	}


### PR DESCRIPTION
Refactors checkDataCentrallyAvailable:
 - error handling instead of logs
 - ssh command's output is output into an io.Writer parameter
 - error message improvements