### PR TITLE
refactor/get local filelist

### DIFF
--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -423,7 +423,7 @@ For Windows you need instead to specify -user username:password on the command l
 			log.Printf("Number of datasets not stored because of too many files:%v\nPlease note that this will cancel any subsequent archive steps from this job !\n", tooLargeDatasets)
 		}
 		color.Unset()
-		//datasetIngestor.PrintFileInfos() // TODO: move this into cmd portion
+
 		// print file statistics
 		if skippedLinks > 0 {
 			color.Set(color.FgYellow)

--- a/datasetIngestor/getLocalFileList.go
+++ b/datasetIngestor/getLocalFileList.go
@@ -4,7 +4,6 @@ package datasetIngestor
 import (
 	"bufio"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -76,16 +75,17 @@ func GetLocalFileList(sourceFolder string, filelistingPath string, symlinkCallba
 	var lines []string
 
 	if filelistingPath == "" {
-		log.Printf("No explicit filelistingPath defined - full folder %s is used.\n", sourceFolder)
+		//log.Printf("No explicit filelistingPath defined - full folder %s is used.\n", sourceFolder)
 		lines = append(lines, "./")
 	} else {
 		lines, err = readLines(filelistingPath)
 		if err != nil {
-			log.Fatalf("readLines: %s", err)
+			//log.Fatalf("readLines: %s", err)
+			return []Datafile{}, time.Time{}, time.Time{}, "", 0, 0, err
 		}
-		for i, line := range lines {
+		/*for i, line := range lines {
 			log.Println(i, line)
-		}
+		}*/
 	}
 
 	// TODO verify that filelisting have no overlap, e.g. no lines X/ and X/Y,
@@ -94,7 +94,7 @@ func GetLocalFileList(sourceFolder string, filelistingPath string, symlinkCallba
 	// restore oldWorkDir after function
 	oldWorkDir, err := os.Getwd()
 	if err != nil {
-		return fullFileArray, startTime, endTime, owner, numFiles, totalSize, err
+		return []Datafile{}, time.Time{}, time.Time{}, "", 0, 0, err
 	}
 
 	defer os.Chdir(oldWorkDir)
@@ -106,14 +106,14 @@ func GetLocalFileList(sourceFolder string, filelistingPath string, symlinkCallba
 	}
 
 	if err := os.Chdir(sourceFolder); err != nil {
-		log.Printf("Can not step into sourceFolder %v - dataset will be ignored.\n", sourceFolder)
-		return fullFileArray, startTime, endTime, owner, numFiles, totalSize, err
+		//log.Printf("Can not step into sourceFolder %v - dataset will be ignored.\n", sourceFolder)
+		return []Datafile{}, time.Time{}, time.Time{}, "", 0, 0, err
 	}
-	dir, err := os.Getwd()
+	/*dir, err := os.Getwd()
 	if err != nil {
 		return fullFileArray, startTime, endTime, owner, numFiles, totalSize, err
 	}
-	log.Printf("Scanning source folder: %s at %s", sourceFolder, dir)
+	log.Printf("Scanning source folder: %s at %s", sourceFolder, dir)*/
 
 	// spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond) // spinner for progress indication
 	// spin.Writer = os.Stderr
@@ -125,10 +125,10 @@ func GetLocalFileList(sourceFolder string, filelistingPath string, symlinkCallba
 		}
 
 		// spin.Start() // Start the spinner
-		e := filepath.Walk(line, func(path string, f os.FileInfo, err error) error {
+		err := filepath.Walk(line, func(path string, f os.FileInfo, err error) error {
 			// ignore ./ (but keep other dot files)
 			if f == nil || f.Name() == "" {
-				log.Printf("Skipping file or directory %s", path)
+				//log.Printf("Skipping file or directory %s", path)
 				return nil
 			}
 			if f.IsDir() && f.Name() == "." {
@@ -191,8 +191,8 @@ func GetLocalFileList(sourceFolder string, filelistingPath string, symlinkCallba
 			return err
 		})
 
-		if e != nil {
-			log.Fatal("Fatal error:", e)
+		if err != nil {
+			return []Datafile{}, time.Time{}, time.Time{}, "", 0, 0, fmt.Errorf("file walk returned error: %v", err)
 		}
 	}
 	// spin.Stop()

--- a/datasetIngestor/getLocalFileList.go
+++ b/datasetIngestor/getLocalFileList.go
@@ -203,15 +203,15 @@ func handleSymlink(symlinkPath string, sourceFolder string) (bool, error) {
 	keep := true
 	pointee, _ := os.Readlink(symlinkPath) // just pass the file name
 	if !filepath.IsAbs(pointee) {
-		dir, err := filepath.Abs(filepath.Dir(symlinkPath))
+		symlinkAbs, err := filepath.Abs(filepath.Dir(symlinkPath))
 		if err != nil {
 			keep = false
 			err = fmt.Errorf("could not find absolute path of symlink at \"%s\": %v", symlinkPath, err)
 			return false, err
 		}
 		// log.Printf(" CWD path pointee :%v %v %v", dir, filepath.Dir(path), pointee)
-		pabs := filepath.Join(dir, filepath.Dir(symlinkPath), pointee)
-		pointee, err = filepath.EvalSymlinks(pabs)
+		pointeeAbs := filepath.Join(symlinkAbs, pointee)
+		pointee, err = filepath.EvalSymlinks(pointeeAbs)
 		if err != nil {
 			keep = false
 			err = fmt.Errorf("could not follow symlink: %v", err)

--- a/datasetIngestor/getLocalFileList_test.go
+++ b/datasetIngestor/getLocalFileList_test.go
@@ -23,8 +23,7 @@ func TestAssembleFilelisting(t *testing.T) {
 	}
 
 	// Call AssembleFilelisting on the temporary directory
-	skip := ""
-	fullFileArray, startTime, endTime, _, numFiles, totalSize, err := GetLocalFileList(tempDir, "", &skip)
+	fullFileArray, startTime, endTime, _, numFiles, totalSize, err := GetLocalFileList(tempDir, "", nil, nil)
 	if err != nil {
 		t.Errorf("got error: %v", err)
 	}


### PR DESCRIPTION
This overhauls the local filelist gathering function:
 - The function now uses callbacks for symlink handling and filename checking
 - Better error handling
 - No unwanted logging from a library function
 - If no callbacks are provided, sensible defaults are used