### PR TITLE
Feature/globus transfer

### DIFF
--- a/cmd/cliutils/commonTransfer.go
+++ b/cmd/cliutils/commonTransfer.go
@@ -1,0 +1,24 @@
+package cliutils
+
+import (
+	"net/http"
+
+	"github.com/SwissOpenEM/globus"
+)
+
+type TransferParams struct {
+	// ssh transfer
+	Client          *http.Client
+	ApiServer       string
+	User            map[string]string
+	RsyncServer     string
+	AbsFilelistPath string
+	// globus transfer
+	GlobusClient   globus.GlobusClient
+	SrcCollection  string
+	DestCollection string
+	Filelist       []string
+	// dataset params
+	DatasetId           string
+	DatasetSourceFolder string
+}

--- a/cmd/cliutils/commonTransfer.go
+++ b/cmd/cliutils/commonTransfer.go
@@ -6,19 +6,26 @@ import (
 	"github.com/SwissOpenEM/globus"
 )
 
-type TransferParams struct {
-	// ssh transfer
+type SshParams struct {
 	Client          *http.Client
 	ApiServer       string
 	User            map[string]string
 	RsyncServer     string
 	AbsFilelistPath string
-	// globus transfer
+}
+
+type GlobusParams struct {
 	GlobusClient   globus.GlobusClient
 	SrcCollection  string
 	DestCollection string
 	Filelist       []string
-	// dataset params
+	IsSymlinkList  []bool
+}
+
+type TransferParams struct {
+	SshParams
+	GlobusParams
+	// other params
 	DatasetId           string
 	DatasetSourceFolder string
 }

--- a/cmd/cliutils/commonTransfer.go
+++ b/cmd/cliutils/commonTransfer.go
@@ -17,7 +17,9 @@ type SshParams struct {
 type GlobusParams struct {
 	GlobusClient   globus.GlobusClient
 	SrcCollection  string
+	SrcPrefixPath  string
 	DestCollection string
+	DestPrefixPath string
 	Filelist       []string
 	IsSymlinkList  []bool
 }

--- a/cmd/cliutils/consts.go
+++ b/cmd/cliutils/consts.go
@@ -1,0 +1,3 @@
+package cliutils
+
+const TOTAL_MAXFILES = 400000

--- a/cmd/cliutils/globusLogin.go
+++ b/cmd/cliutils/globusLogin.go
@@ -1,0 +1,56 @@
+package cliutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/SwissOpenEM/globus"
+	"golang.org/x/oauth2"
+	"gopkg.in/yaml.v2"
+)
+
+type globusConfig struct {
+	ClientID              string   `yaml:"client-id"`
+	ClientSecret          string   `yaml:"client-secret,omitempty"`
+	RedirectURL           string   `yaml:"redirect-url"`
+	Scopes                []string `yaml:"scopes,omitempty"`
+	SourceCollection      string   `yaml:"source-collection"`
+	DestinationCollection string   `yaml:"dest-collection"`
+}
+
+func GlobusLogin(confPath string) (gClient globus.GlobusClient, srcCollection string, destCollection string, err error) {
+	// read in config
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		return globus.GlobusClient{}, "", "", fmt.Errorf("can't read globus config: %v", err)
+	}
+	var gConfig globusConfig
+	err = yaml.Unmarshal(data, &gConfig)
+	if err != nil {
+		return globus.GlobusClient{}, "", "", fmt.Errorf("can't unmarshal globus config: %v", err)
+	}
+
+	// config setup
+	ctx := context.Background()
+	clientConfig := globus.AuthGenerateOauthClientConfig(ctx, gConfig.ClientID, gConfig.ClientSecret, gConfig.RedirectURL, gConfig.Scopes)
+	verifier := oauth2.GenerateVerifier()
+	clientConfig.AuthCodeURL("state", oauth2.AccessTypeOffline, oauth2.S256ChallengeOption(verifier))
+
+	// redirect user to consent page to ask for permission and obtain the code
+	url := clientConfig.AuthCodeURL("state", oauth2.AccessTypeOffline, oauth2.S256ChallengeOption(verifier))
+	fmt.Printf("Visit the URL for the auth dialog: %v\n\nEnter the received code here: ", url)
+
+	// negotiate token and create client
+	var code string
+	if _, err := fmt.Scan(&code); err != nil {
+		return globus.GlobusClient{}, "", "", err
+	}
+	tok, err := clientConfig.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return globus.GlobusClient{}, "", "", fmt.Errorf("oauth2 exchange failed: %v", err)
+	}
+
+	// return globus client
+	return globus.HttpClientToGlobusClient(clientConfig.Client(ctx, tok)), gConfig.SourceCollection, gConfig.DestinationCollection, nil
+}

--- a/cmd/cliutils/globusLogin.go
+++ b/cmd/cliutils/globusLogin.go
@@ -16,19 +16,21 @@ type globusConfig struct {
 	RedirectURL           string   `yaml:"redirect-url"`
 	Scopes                []string `yaml:"scopes,omitempty"`
 	SourceCollection      string   `yaml:"source-collection"`
-	DestinationCollection string   `yaml:"dest-collection"`
+	SourcePrefixPath      string   `yaml:"source-prefix-path,omitempty"`
+	DestinationCollection string   `yaml:"destination-collection"`
+	DestinationPrefixPath string   `yaml:"destination-prefix-path,omitempty"`
 }
 
-func GlobusLogin(confPath string) (gClient globus.GlobusClient, srcCollection string, destCollection string, err error) {
+func GlobusLogin(confPath string) (gClient globus.GlobusClient, srcCollection string, srcPrefixPath string, destCollection string, destPrefixPath string, err error) {
 	// read in config
 	data, err := os.ReadFile(confPath)
 	if err != nil {
-		return globus.GlobusClient{}, "", "", fmt.Errorf("can't read globus config: %v", err)
+		return globus.GlobusClient{}, "", "", "", "", fmt.Errorf("can't read globus config: %v", err)
 	}
 	var gConfig globusConfig
 	err = yaml.Unmarshal(data, &gConfig)
 	if err != nil {
-		return globus.GlobusClient{}, "", "", fmt.Errorf("can't unmarshal globus config: %v", err)
+		return globus.GlobusClient{}, "", "", "", "", fmt.Errorf("can't unmarshal globus config: %v", err)
 	}
 
 	// config setup
@@ -44,13 +46,13 @@ func GlobusLogin(confPath string) (gClient globus.GlobusClient, srcCollection st
 	// negotiate token and create client
 	var code string
 	if _, err := fmt.Scan(&code); err != nil {
-		return globus.GlobusClient{}, "", "", err
+		return globus.GlobusClient{}, "", "", "", "", err
 	}
 	tok, err := clientConfig.Exchange(ctx, code, oauth2.VerifierOption(verifier))
 	if err != nil {
-		return globus.GlobusClient{}, "", "", fmt.Errorf("oauth2 exchange failed: %v", err)
+		return globus.GlobusClient{}, "", "", "", "", fmt.Errorf("oauth2 exchange failed: %v", err)
 	}
 
 	// return globus client
-	return globus.HttpClientToGlobusClient(clientConfig.Client(ctx, tok)), gConfig.SourceCollection, gConfig.DestinationCollection, nil
+	return globus.HttpClientToGlobusClient(clientConfig.Client(ctx, tok)), gConfig.SourceCollection, gConfig.SourcePrefixPath, gConfig.DestinationCollection, gConfig.DestinationPrefixPath, nil
 }

--- a/cmd/cliutils/globusTransfer.go
+++ b/cmd/cliutils/globusTransfer.go
@@ -9,6 +9,8 @@ func GlobusTransfer(params TransferParams) (archivable bool, err error) {
 	// === collecting params. ===
 	globusClient := params.GlobusClient
 
+	fileList := params.Filelist
+	isSymlinkList := params.IsSymlinkList
 	srcCollection := params.SrcCollection
 	dsSourceFolder := params.DatasetSourceFolder
 
@@ -20,7 +22,7 @@ func GlobusTransfer(params TransferParams) (archivable bool, err error) {
 
 	// === copying files ===
 	log.Println("Syncing files to cache server...")
-	result, err := globusClient.TransferFileList(srcCollection, dsSourceFolder, destCollection, destFolder, []string{}, []bool{})
+	result, err := globusClient.TransferFileList(srcCollection, dsSourceFolder, destCollection, destFolder, fileList, isSymlinkList, true)
 	log.Printf("The transfer result response: \n=====\n%v\n=====\n", result)
 	log.Println("Syncing files - STARTED")
 

--- a/cmd/cliutils/globusTransfer.go
+++ b/cmd/cliutils/globusTransfer.go
@@ -1,0 +1,29 @@
+package cliutils
+
+import (
+	"log"
+	"strings"
+)
+
+func GlobusTransfer(params TransferParams) (archivable bool, err error) {
+	// === collecting params. ===
+	globusClient := params.GlobusClient
+
+	srcCollection := params.SrcCollection
+	dsSourceFolder := params.DatasetSourceFolder
+
+	destCollection := params.DestCollection
+	datasetId := params.DatasetId
+
+	archivable = false // the dataset is never archivable after a globus transfer request immediately
+	destFolder := "archive/" + strings.Split(datasetId, "/")[1] + dsSourceFolder
+
+	// === copying files ===
+	log.Println("Syncing files to cache server...")
+	result, err := globusClient.TransferFileList(srcCollection, dsSourceFolder, destCollection, destFolder, []string{}, []bool{})
+	log.Printf("The transfer result response: \n=====\n%v\n=====\n", result)
+	log.Println("Syncing files - STARTED")
+
+	// === return results ===
+	return archivable, err
+}

--- a/cmd/cliutils/globusTransfer.go
+++ b/cmd/cliutils/globusTransfer.go
@@ -12,18 +12,29 @@ func GlobusTransfer(params TransferParams) (archivable bool, err error) {
 	fileList := params.Filelist
 	isSymlinkList := params.IsSymlinkList
 	srcCollection := params.SrcCollection
+	srcPrefixPath := params.SrcPrefixPath
 	dsSourceFolder := params.DatasetSourceFolder
 
 	destCollection := params.DestCollection
+	destPrefixPath := params.DestPrefixPath
 	datasetId := params.DatasetId
 
 	archivable = false // the dataset is never archivable after a globus transfer request immediately
-	destFolder := "archive/" + strings.Split(datasetId, "/")[1] + dsSourceFolder
+	destFolder := destPrefixPath + "/archive/" + strings.Split(datasetId, "/")[1] + dsSourceFolder
+
+	for i := range fileList {
+		fileList[i] = srcPrefixPath + "/" + fileList[i]
+	}
 
 	// === copying files ===
 	log.Println("Syncing files to cache server...")
 	result, err := globusClient.TransferFileList(srcCollection, dsSourceFolder, destCollection, destFolder, fileList, isSymlinkList, true)
-	log.Printf("The transfer result response: \n=====\n%v\n=====\n", result)
+	log.Printf("The transfer result response: \n=====\n")
+	log.Printf("Task ID: %s\n", result.TaskId)
+	log.Printf("Code: %s\n", result.SubmissionId)
+	log.Printf("Message: %s\n", result.Message)
+	log.Printf("Resource: %s\n", result.Resource)
+	log.Printf("=====\n")
 	log.Println("Syncing files - STARTED")
 
 	// === return results ===

--- a/cmd/cliutils/sshTransfer.go
+++ b/cmd/cliutils/sshTransfer.go
@@ -1,0 +1,32 @@
+package cliutils
+
+import (
+	"log"
+	"os"
+
+	"github.com/paulscherrerinstitute/scicat/datasetIngestor"
+)
+
+func SshTransfer(params TransferParams) (archivable bool, err error) {
+	// === collecting params. ===
+	client := params.Client
+	apiServer := params.ApiServer
+	user := params.User
+	rsyncServer := params.RsyncServer
+	datasetId := params.DatasetId
+	dsSourceFolder := params.DatasetSourceFolder
+	absFilelistPath := params.AbsFilelistPath
+	archivable = false
+
+	// === copying files ===
+	log.Println("Syncing files to cache server...")
+	err = datasetIngestor.SyncLocalDataToFileserver(datasetId, user, rsyncServer, dsSourceFolder, absFilelistPath, os.Stdout)
+	if err == nil {
+		// mark dataset ready for archival
+		archivable = true
+		err = datasetIngestor.MarkFilesReady(client, apiServer, datasetId, user)
+	}
+	log.Println("Syncing files - DONE")
+
+	return archivable, err
+}

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -93,31 +93,29 @@ For Windows you need instead to specify -user username:password on the command l
 		var globusClient globus.GlobusClient
 		var gConfig cliutils.GlobusConfig
 
-		if copyFlag {
-			switch transferType {
-			case Ssh:
-				transferFiles = cliutils.SshTransfer
-			case Globus:
-				transferFiles = cliutils.GlobusTransfer
-				var globusConfigPath string
-				if cmd.Flags().Lookup("globus-cfg").Changed {
-					globusConfigPath = globusCfgFlag
-				} else {
-					execPath, err := os.Executable()
-					if err != nil {
-						log.Fatalln("can't find executable path:", err)
-					}
-					globusConfigPath = filepath.Join(filepath.Dir(execPath), "globus.yaml")
-				}
-
-				globusClient, gConfig, err = cliutils.GlobusLogin(globusConfigPath)
+		switch transferType {
+		case Ssh:
+			transferFiles = cliutils.SshTransfer
+		case Globus:
+			transferFiles = cliutils.GlobusTransfer
+			var globusConfigPath string
+			if cmd.Flags().Lookup("globus-cfg").Changed {
+				globusConfigPath = globusCfgFlag
+			} else {
+				execPath, err := os.Executable()
 				if err != nil {
-					log.Fatalln("couldn't create globus client:", err)
+					log.Fatalln("can't find executable path:", err)
 				}
+				globusConfigPath = filepath.Join(filepath.Dir(execPath), "globus.yaml")
+			}
 
-				if autoarchiveFlag {
-					log.Fatalln("Cannot autoarchive when transferring via Globus due to the transfer happening asynchronously. Use the \"globusCheckTransfer\" command to archive them")
-				}
+			globusClient, gConfig, err = cliutils.GlobusLogin(globusConfigPath)
+			if err != nil {
+				log.Fatalln("couldn't create globus client:", err)
+			}
+
+			if autoarchiveFlag {
+				log.Fatalln("Cannot autoarchive when transferring via Globus due to the transfer happening asynchronously. Use the \"globusCheckTransfer\" command to archive them")
 			}
 		}
 

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -91,7 +91,7 @@ For Windows you need instead to specify -user username:password on the command l
 
 		// globus specific vars (if needed)
 		var globusClient globus.GlobusClient
-		var srcCollection, srcPrefixPath, destCollection, destPrefixPath string
+		var gConfig cliutils.GlobusConfig
 
 		switch transferType {
 		case Ssh:
@@ -109,7 +109,7 @@ For Windows you need instead to specify -user username:password on the command l
 				globusConfigPath = filepath.Join(filepath.Dir(execPath), "globus.yaml")
 			}
 
-			globusClient, srcCollection, srcPrefixPath, destCollection, destPrefixPath, err = cliutils.GlobusLogin(globusConfigPath)
+			globusClient, gConfig, err = cliutils.GlobusLogin(globusConfigPath)
 			if err != nil {
 				log.Fatalln("couldn't create globus client:", err)
 			}
@@ -449,10 +449,10 @@ For Windows you need instead to specify -user username:password on the command l
 						},
 						GlobusParams: cliutils.GlobusParams{
 							GlobusClient:   globusClient,
-							SrcCollection:  srcCollection,
-							SrcPrefixPath:  srcPrefixPath,
-							DestCollection: destCollection,
-							DestPrefixPath: destPrefixPath,
+							SrcCollection:  gConfig.SourceCollection,
+							SrcPrefixPath:  gConfig.SourcePrefixPath,
+							DestCollection: gConfig.DestinationCollection,
+							DestPrefixPath: gConfig.DestinationPrefixPath,
 							Filelist:       filePathList,
 							IsSymlinkList:  isSymlinkList,
 						},

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -115,7 +115,7 @@ For Windows you need instead to specify -user username:password on the command l
 			}
 
 			if autoarchiveFlag {
-				log.Println("Cannot autoarchive when transfering via Globus due to the transfer happening asynchronously. Use the \"globusCheckTransfer\" command to archive them")
+				log.Println("Cannot autoarchive when transferring via Globus due to the transfer happening asynchronously. Use the \"globusCheckTransfer\" command to archive them")
 				autoarchiveFlag = false
 			}
 		}
@@ -547,7 +547,7 @@ func init() {
 	datasetIngestorCmd.Flags().Bool("noninteractive", false, "If set no questions will be asked and the default settings for all undefined flags will be assumed")
 	datasetIngestorCmd.Flags().Bool("copy", false, "Defines if files should be copied from your local system to a central server before ingest (i.e. your data is not centrally available and therefore needs to be copied ='decentral' case). copyFlag has higher priority than nocopyFlag. If neither flag is defined the tool will try to make the best guess.")
 	datasetIngestorCmd.Flags().Bool("nocopy", false, "Defines if files should *not* be copied from your local system to a central server before ingest (i.e. your data is centrally available and therefore does not need to be copied ='central' case).")
-	datasetIngestorCmd.Flags().String("transfer-type", "ssh", "Selects the transfer type to be used for transfering files. Available options: \"ssh\", \"globus\"")
+	datasetIngestorCmd.Flags().String("transfer-type", "ssh", "Selects the transfer type to be used for transferring files. Available options: \"ssh\", \"globus\"")
 	datasetIngestorCmd.Flags().Int("tapecopies", 0, "Number of tapecopies to be used for archiving")
 	datasetIngestorCmd.Flags().Bool("autoarchive", false, "Option to create archive job automatically after ingestion")
 	datasetIngestorCmd.Flags().String("linkfiles", "keepInternalOnly", "Define what to do with symbolic links: (keep|delete|keepInternalOnly)")

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -431,7 +431,6 @@ For Windows you need instead to specify -user username:password on the command l
 			log.Printf("Number of datasets not stored because of too many files:%v\nPlease note that this will cancel any subsequent archive steps from this job !\n", tooLargeDatasets)
 		}
 		color.Unset()
-
 		// print file statistics
 		if skippedLinks > 0 {
 			color.Set(color.FgYellow)

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -239,7 +239,7 @@ For Windows you need instead to specify -user username:password on the command l
 		// a destination location is defined by the archive system
 		// for now let the user decide if he needs a copy
 
-		if nocopyFlag {
+		if nocopyFlag || beamlineAccount {
 			copyFlag = false
 		}
 		checkCentralAvailability := !(cmd.Flags().Changed("copy") || cmd.Flags().Changed("nocopy") || beamlineAccount || copyFlag)

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -93,30 +93,31 @@ For Windows you need instead to specify -user username:password on the command l
 		var globusClient globus.GlobusClient
 		var gConfig cliutils.GlobusConfig
 
-		switch transferType {
-		case Ssh:
-			transferFiles = cliutils.SshTransfer
-		case Globus:
-			transferFiles = cliutils.GlobusTransfer
-			var globusConfigPath string
-			if cmd.Flags().Lookup("globus-cfg").Changed {
-				globusConfigPath = globusCfgFlag
-			} else {
-				execPath, err := os.Executable()
-				if err != nil {
-					log.Fatalln("can't find executable path:", err)
+		if copyFlag {
+			switch transferType {
+			case Ssh:
+				transferFiles = cliutils.SshTransfer
+			case Globus:
+				transferFiles = cliutils.GlobusTransfer
+				var globusConfigPath string
+				if cmd.Flags().Lookup("globus-cfg").Changed {
+					globusConfigPath = globusCfgFlag
+				} else {
+					execPath, err := os.Executable()
+					if err != nil {
+						log.Fatalln("can't find executable path:", err)
+					}
+					globusConfigPath = filepath.Join(filepath.Dir(execPath), "globus.yaml")
 				}
-				globusConfigPath = filepath.Join(filepath.Dir(execPath), "globus.yaml")
-			}
 
-			globusClient, gConfig, err = cliutils.GlobusLogin(globusConfigPath)
-			if err != nil {
-				log.Fatalln("couldn't create globus client:", err)
-			}
+				globusClient, gConfig, err = cliutils.GlobusLogin(globusConfigPath)
+				if err != nil {
+					log.Fatalln("couldn't create globus client:", err)
+				}
 
-			if autoarchiveFlag {
-				log.Println("Cannot autoarchive when transferring via Globus due to the transfer happening asynchronously. Use the \"globusCheckTransfer\" command to archive them")
-				autoarchiveFlag = false
+				if autoarchiveFlag {
+					log.Fatalln("Cannot autoarchive when transferring via Globus due to the transfer happening asynchronously. Use the \"globusCheckTransfer\" command to archive them")
+				}
 			}
 		}
 

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -91,7 +91,7 @@ For Windows you need instead to specify -user username:password on the command l
 
 		// globus specific vars (if needed)
 		var globusClient globus.GlobusClient
-		var srcCollection, destCollection string
+		var srcCollection, srcPrefixPath, destCollection, destPrefixPath string
 
 		switch transferType {
 		case Ssh:
@@ -106,10 +106,10 @@ For Windows you need instead to specify -user username:password on the command l
 				if err != nil {
 					log.Fatalln("can't find executable path:", err)
 				}
-				globusConfigPath = filepath.Join(execPath, "globus.yaml")
+				globusConfigPath = filepath.Join(filepath.Dir(execPath), "globus.yaml")
 			}
 
-			globusClient, srcCollection, destCollection, err = cliutils.GlobusLogin(globusConfigPath)
+			globusClient, srcCollection, srcPrefixPath, destCollection, destPrefixPath, err = cliutils.GlobusLogin(globusConfigPath)
 			if err != nil {
 				log.Fatalln("couldn't create globus client:", err)
 			}
@@ -450,7 +450,9 @@ For Windows you need instead to specify -user username:password on the command l
 						GlobusParams: cliutils.GlobusParams{
 							GlobusClient:   globusClient,
 							SrcCollection:  srcCollection,
+							SrcPrefixPath:  srcPrefixPath,
 							DestCollection: destCollection,
+							DestPrefixPath: destPrefixPath,
 							Filelist:       filePathList,
 							IsSymlinkList:  isSymlinkList,
 						},

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -282,7 +282,7 @@ For Windows you need instead to specify -user username:password on the command l
 		// a destination location is defined by the archive system
 		// for now let the user decide if he needs a copy
 
-		if nocopyFlag || beamlineAccount {
+		if nocopyFlag {
 			copyFlag = false
 		}
 		checkCentralAvailability := !(cmd.Flags().Changed("copy") || cmd.Flags().Changed("nocopy") || beamlineAccount || copyFlag)

--- a/cmd/commands/globusCheckTransfer.go
+++ b/cmd/commands/globusCheckTransfer.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/paulscherrerinstitute/scicat/cmd/cliutils"
+	"github.com/paulscherrerinstitute/scicat/datasetIngestor"
+	"github.com/paulscherrerinstitute/scicat/datasetUtils"
+	"github.com/spf13/cobra"
+)
+
+var globusCheckTransfer = &cobra.Command{
+	Use:   "globusCheckTransfer [options] (transfer_task_id transfer_task_id ...)",
+	Short: "Checks whether a list of Globus transfers has finished",
+	Long: `Tool for checking whether a list of Globus transfers has finished
+
+You must have a Globus account with access to the desired transfers. Optionally,
+you can save 
+
+For further help see "` + MANUAL + `"`,
+	Args: minArgsWithVersionException(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// consts & vars
+		var client = &http.Client{
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: false}},
+			Timeout:   10 * time.Second}
+
+		var APIServer string = PROD_API_SERVER
+
+		// pass parameters
+		testenvFlag, _ := cmd.Flags().GetBool("testenv")
+		devenvFlag, _ := cmd.Flags().GetBool("devenv")
+		localenvFlag, _ := cmd.Flags().GetBool("localenv")
+		tunnelenvFlag, _ := cmd.Flags().GetBool("tunnelenv")
+		userpass, _ := cmd.Flags().GetString("user")
+		token, _ := cmd.Flags().GetString("token")
+		showVersion, _ := cmd.Flags().GetBool("version")
+		globusCfgFlag, _ := cmd.Flags().GetString("globus-cfg")
+		markArchivable, _ := cmd.Flags().GetBool("mark-archivable")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		autoarchiveFlag, _ := cmd.Flags().GetBool("autoarchive")
+		tapecopies, _ := cmd.Flags().GetInt("tapecopies")
+
+		if datasetUtils.TestFlags != nil {
+			datasetUtils.TestFlags(map[string]interface{}{
+				"testenv":         testenvFlag,
+				"devenv":          devenvFlag,
+				"localenv":        localenvFlag,
+				"tunnelenv":       tunnelenvFlag,
+				"user":            userpass,
+				"token":           token,
+				"version":         showVersion,
+				"globus-cfg":      globusCfgFlag,
+				"mark-archivable": globusCfgFlag,
+				"dry-run":         dryRun,
+				"autoarchive":     autoarchiveFlag,
+				"tapecopies":      tapecopies,
+			})
+			return
+		}
+
+		// === execute command ===
+
+		// show version
+		if showVersion {
+			fmt.Printf("%s\n", VERSION)
+			return
+		}
+
+		datasetUtils.CheckForNewVersion(client, "dummystring", VERSION)
+
+		// since Cobra doesn't support one way dependent flags, we have to do this:
+		if !markArchivable && (dryRun || autoarchiveFlag || tapecopies > 0) {
+			log.Fatalln("Can't use \"dry-run\", \"autoarchive\" or \"tapecopies\" if \"mark-archivable\" is not set.")
+		}
+		if !autoarchiveFlag && tapecopies > 0 {
+			log.Fatalln("Can't use \"tapecopies\" if \"autoarchive\" is not set.")
+		}
+
+		// find globus config
+		var globusConfigPath string
+		if cmd.Flags().Lookup("globus-cfg").Changed {
+			globusConfigPath = globusCfgFlag
+		} else {
+			execPath, err := os.Executable()
+			if err != nil {
+				log.Fatalln("can't find executable path:", err)
+			}
+			globusConfigPath = filepath.Join(execPath, "globus.yaml")
+		}
+
+		// environment overrides
+		if tunnelenvFlag {
+			APIServer = TUNNEL_API_SERVER
+		}
+		if localenvFlag {
+			APIServer = LOCAL_API_SERVER
+		}
+		if devenvFlag {
+			APIServer = DEV_API_SERVER
+		}
+		if testenvFlag {
+			APIServer = TEST_API_SERVER
+		}
+
+		// start message
+		startMessage := "Checking transfer complpetion"
+		if markArchivable {
+			startMessage += ", archivability"
+		}
+		if autoarchiveFlag {
+			startMessage += " and attempting auto-archival"
+		}
+		startMessage += " of the datasets corresponding to the following transfer tasks:\n"
+
+		color.Set(color.FgGreen)
+		log.Println(startMessage)
+		for _, task := range args {
+			fmt.Printf(" - %s\n", task)
+		}
+		color.Unset()
+
+		// logging into scicat and globus...
+		var user map[string]string
+		if markArchivable {
+			user, _ = authenticate(RealAuthenticator{}, client, APIServer, userpass, token)
+		}
+
+		globusClient, _, _, err := cliutils.GlobusLogin(globusConfigPath)
+		if err != nil {
+			log.Fatalf("Couldn't create globus client: %v\n", err)
+		}
+
+		// go through each transfer task, and execute the requested operations
+		var archivableDatasetList []string
+		for _, taskId := range args {
+			task, err := globusClient.TransferGetTaskByID(taskId)
+			if err != nil {
+				log.Printf("Transfer task with ID \"%s\" returned error: %v\n", taskId, err)
+				continue
+			}
+			fmt.Printf("Task status: \n=====\n%v\n=====\n", task)
+
+			// if marking as archivable is requested and the transfer has succeded
+			if markArchivable && task.Status == "SUCCEEDED" {
+				if task.SourceBasePath == nil {
+					log.Printf("Can't get source base path for \"%s\". It will not be marked as archivable, but can be archived.\n", taskId)
+					continue
+				}
+				sourceFolder := *task.SourceBasePath
+				list, err := datasetIngestor.TestForExistingSourceFolder([]string{sourceFolder}, client, APIServer, user["accessToken"])
+
+				// error handling and exceptions
+				if err != nil {
+					log.Printf("WARNING - an error has occured when querying the sourcefolder \"%s\" of task id \"%s\": %v\n", sourceFolder, taskId, err)
+					log.Printf("Can't set %s task's dataset to archivable.\n", taskId)
+					continue
+				}
+				if len(list) <= 0 {
+					log.Printf("WARNING - empty dataset list returned for the sourcefolder \"%s\" of task id \"%s\": %v\n", sourceFolder, taskId, err)
+					log.Printf("Can't set %s task's dataset to archivable.\n", taskId)
+					continue
+				}
+				if dryRun {
+					log.Println("list of found datasets:")
+					for _, result := range list {
+						fmt.Printf(" - %s\n", result.Pid)
+					}
+					log.Println("since dry-run is set, the command will not attempt to mark the above datasets as archivable, or try to archive them")
+					continue
+				}
+
+				for _, result := range list {
+					log.Printf("%s dataset is being marked as archivable...\n", result.Pid)
+					err := datasetIngestor.MarkFilesReady(client, APIServer, result.Pid, user)
+					if err != nil {
+						log.Printf("WARNING - error occured while trying to mark files ready for dataset with PID \"%s\": %v\n", result.Pid, err)
+						log.Printf("%s dataset was (likely) not marked archivable.\n", result.Pid)
+						continue
+					}
+					log.Printf("%s dataset was successfully marked as archivable.\n", result.Pid)
+					archivableDatasetList = append(archivableDatasetList, result.Pid)
+				}
+			}
+
+			// if marking as archivable is requested but the transfer has *not* succeeded
+			if markArchivable && task.Status != "SUCCEEDED" {
+				log.Printf("%s task's status is %s, the corresponding dataset can't be marked as archivable.\n", taskId, task.Status)
+			}
+		}
+
+		// === create archive job ===
+		if autoarchiveFlag {
+			log.Printf("Submitting Archive Job for archivable datasets.\n")
+			// TODO: change param type from pointer to regular as it is unnecessary
+			//   for it to be passed as pointer
+			jobId, err := datasetUtils.CreateArchivalJob(client, APIServer, user, archivableDatasetList, &tapecopies)
+			if err != nil {
+				color.Set(color.FgRed)
+				log.Printf("Could not create the archival job for the ingested datasets: %s", err.Error())
+				color.Unset()
+			}
+			log.Println("Submitted job:", jobId)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(globusCheckTransfer)
+
+	globusCheckTransfer.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
+	globusCheckTransfer.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")
+	globusCheckTransfer.Flags().Bool("localenv", false, "Use local environment instead of production environment (developers only)")
+	globusCheckTransfer.Flags().Bool("tunnelenv", false, "Use tunneled API server at port 5443 to access development instance (developers only)")
+	globusCheckTransfer.Flags().String("globus-cfg", "", "Override globus transfer config file location [default: globus.yaml next to executable]")
+	globusCheckTransfer.Flags().Bool("mark-archivable", false, "")
+	globusCheckTransfer.Flags().Bool("dry-run", false, "")
+	globusCheckTransfer.Flags().Bool("autoarchive", false, "")
+	globusCheckTransfer.Flags().Int("tapecopies", 0, "Number of tapecopies to be used for archiving")
+
+	globusCheckTransfer.MarkFlagsMutuallyExclusive("testenv", "devenv", "localenv", "tunnelenv")
+	globusCheckTransfer.MarkFlagsMutuallyExclusive("dry-run", "autoarchive")
+	globusCheckTransfer.MarkFlagsMutuallyExclusive("dry-run", "tapecopies")
+}

--- a/cmd/commands/globusCheckTransfer.go
+++ b/cmd/commands/globusCheckTransfer.go
@@ -136,7 +136,7 @@ For further help see "` + MANUAL + `"`,
 			user, _ = authenticate(RealAuthenticator{}, client, APIServer, userpass, token)
 		}
 
-		globusClient, _, srcPrefixPath, _, _, err := cliutils.GlobusLogin(globusConfigPath)
+		globusClient, gConfig, err := cliutils.GlobusLogin(globusConfigPath)
 		if err != nil {
 			log.Fatalf("Couldn't create globus client: %v\n", err)
 		}
@@ -160,7 +160,7 @@ For further help see "` + MANUAL + `"`,
 
 				// get source and dest folders
 				sourceFolder := *task.SourceBasePath
-				sourceFolder = strings.TrimPrefix(sourceFolder, srcPrefixPath)
+				sourceFolder = strings.TrimPrefix(sourceFolder, gConfig.SourcePrefixPath)
 				sourceFolder = strings.TrimSuffix(sourceFolder, "/")
 				var destFolder string
 				if !skipDestPathCheck {

--- a/cmd/commands/globusCheckTransfer.go
+++ b/cmd/commands/globusCheckTransfer.go
@@ -151,7 +151,7 @@ For further help see "` + MANUAL + `"`,
 			}
 			fmt.Printf("Task status: \n=====\n%v\n=====\n", task)
 
-			// if marking as archivable is requested and the transfer has succeded
+			// if marking as archivable is requested and the transfer has succeeded
 			if markArchivable && task.Status == "SUCCEEDED" {
 				if task.SourceBasePath == nil {
 					log.Printf("Can't get source base path for task \"%s\". It will not be marked as archivable, but can probably be archived.\n", taskId)
@@ -175,7 +175,7 @@ For further help see "` + MANUAL + `"`,
 
 				// error handling and exceptions
 				if err != nil {
-					log.Printf("WARNING - an error has occured when querying the sourcefolder \"%s\" of task id \"%s\": %v\n", sourceFolder, taskId, err)
+					log.Printf("WARNING - an error has occurred when querying the sourcefolder \"%s\" of task id \"%s\": %v\n", sourceFolder, taskId, err)
 					log.Printf("Can't set %s task's dataset to archivable.\n", taskId)
 					continue
 				}
@@ -209,7 +209,7 @@ For further help see "` + MANUAL + `"`,
 					log.Printf("%s dataset is being marked as archivable...\n", result.Pid)
 					err := datasetIngestor.MarkFilesReady(client, APIServer, result.Pid, user)
 					if err != nil {
-						log.Printf("WARNING - error occured while trying to mark files ready for dataset with PID \"%s\": %v\n", result.Pid, err)
+						log.Printf("WARNING - error occurred while trying to mark files ready for dataset with PID \"%s\": %v\n", result.Pid, err)
 						log.Printf("%s dataset was (likely) not marked archivable.\n", result.Pid)
 						continue
 					}

--- a/cmd/commands/globusCheckTransfer.go
+++ b/cmd/commands/globusCheckTransfer.go
@@ -203,7 +203,7 @@ func globusCheckTransferHandleTransferTask(
 	task, err := globusClient.TransferGetTaskByID(taskId)
 	if err != nil {
 		log.Printf("Transfer task with ID \"%s\" returned error: %v\n", taskId, err)
-		return
+		return []string{}
 	}
 	fmt.Printf("Task status: \n=====\n%v\n=====\n", task)
 

--- a/cmd/commands/transferType.go
+++ b/cmd/commands/transferType.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+type transferType int
+
+const (
+	Ssh transferType = iota
+	Globus
+)
+
+func convertToTransferType(input string) (transferType, error) {
+	input = strings.ToLower(input)
+	switch input {
+	case "ssh":
+		return Ssh, nil
+	case "globus":
+		return Globus, nil
+	}
+	return Ssh, fmt.Errorf("invalid transfer type was given: %s", input)
+}

--- a/cmd/globus-config-example.yaml
+++ b/cmd/globus-config-example.yaml
@@ -1,0 +1,11 @@
+client-id: CLIENT_ID_HERE
+client-secret: (OPTIONAL)CLIENT_SECRET_HERE
+redirect-url: REDIRECT_URL_HERE
+scopes:
+ - (optional)
+ - scopes
+ - here
+source-collection: SOURCE_COLLECTION_UUID_HERE
+source-prefix-path: (OPTIONAL)SOURCE_PREFIX_PATH_HERE
+destination-collection: DESTINATION_COLLECTION_UUID_HERE
+destination-prefix-path: (OPTIONAL)DESTINATION_PREFIX_PATH_HERE

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,21 @@
 module github.com/paulscherrerinstitute/scicat
 
-go 1.21
+go 1.22.2
+
+toolchain go1.22.5
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
+	github.com/SwissOpenEM/globus v0.0.0-20240814154422-e0bfef9e2941
 	github.com/fatih/color v1.13.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.17.0
+	golang.org/x/oauth2 v0.19.0
+	golang.org/x/term v0.15.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -20,8 +26,6 @@ require (
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/term v0.15.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.5
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
-	github.com/SwissOpenEM/globus v0.0.0-20240814154422-e0bfef9e2941
+	github.com/SwissOpenEM/globus v0.0.0-20240821075902-f0341ffd7619
 	github.com/fatih/color v1.13.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.5
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
-	github.com/SwissOpenEM/globus v0.0.0-20240821075902-f0341ffd7619
+	github.com/SwissOpenEM/globus v0.0.0-20240822132653-119ec5e19eab
 	github.com/fatih/color v1.13.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/SwissOpenEM/globus v0.0.0-20240814154422-e0bfef9e2941 h1:q3Ba2EPs7Al8EwdwS9m53MxHrey2JDJswiSS9yhH890=
+github.com/SwissOpenEM/globus v0.0.0-20240814154422-e0bfef9e2941/go.mod h1:HiMwPdtUdztPpnA0TamNWBBRPGYjEJWXSRUIV5vjqXc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -8,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
@@ -31,6 +35,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/oauth2 v0.19.0 h1:9+E/EZBCbTLNrbN35fHv/a/d/mOBatymz1zbtQrXpIg=
+golang.org/x/oauth2 v0.19.0/go.mod h1:vYi7skDa1x015PmRRYZ7+s1cWyPgrPiSYRe4rnsexc8=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/SwissOpenEM/globus v0.0.0-20240814154422-e0bfef9e2941 h1:q3Ba2EPs7Al8EwdwS9m53MxHrey2JDJswiSS9yhH890=
-github.com/SwissOpenEM/globus v0.0.0-20240814154422-e0bfef9e2941/go.mod h1:HiMwPdtUdztPpnA0TamNWBBRPGYjEJWXSRUIV5vjqXc=
+github.com/SwissOpenEM/globus v0.0.0-20240821075902-f0341ffd7619 h1:FE3z8fPBL8mGsUcG9k8Yxf/wmIRsUfjbbM0t1IDVqB0=
+github.com/SwissOpenEM/globus v0.0.0-20240821075902-f0341ffd7619/go.mod h1:HiMwPdtUdztPpnA0TamNWBBRPGYjEJWXSRUIV5vjqXc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/SwissOpenEM/globus v0.0.0-20240821075902-f0341ffd7619 h1:FE3z8fPBL8mGsUcG9k8Yxf/wmIRsUfjbbM0t1IDVqB0=
-github.com/SwissOpenEM/globus v0.0.0-20240821075902-f0341ffd7619/go.mod h1:HiMwPdtUdztPpnA0TamNWBBRPGYjEJWXSRUIV5vjqXc=
+github.com/SwissOpenEM/globus v0.0.0-20240822132653-119ec5e19eab h1:Kn57UraLrMUdm/fXZM6qD60xh3vd3B9k1I42JIGvcqo=
+github.com/SwissOpenEM/globus v0.0.0-20240822132653-119ec5e19eab/go.mod h1:HiMwPdtUdztPpnA0TamNWBBRPGYjEJWXSRUIV5vjqXc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=


### PR DESCRIPTION
Adds Globus as a way to transfer files:
- integrate globus go library written for the OpenEM project
- abstraction functions for SSH (rsync) and Globus transfers
- abstracted config for both transfer types
- add new command called "globusCheckTransfer" for checking transfers
- "globusCheckTransfer" supports marking datasets as archivable if the transfer succeeds