### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.50.1
+          version: v1.60
           only-new-issues: true


### PR DESCRIPTION
Update golangci-lint from v1.50.1 to v1.60. This is needed to ensure that it works with the latest go versions and corresponding packages.