### PR TITLE
Refactor and test GetDatasetDetailsPublished (add in missing changes from unmerged PR #66)

### DIFF
--- a/cmd/commands/datasetPublishData.go
+++ b/cmd/commands/datasetPublishData.go
@@ -324,6 +324,9 @@ To update the PublishedData entry with the downloadLink you have to run the scri
 
 		// get sourceFolder and other dataset related info for all Datasets
 		datasetDetails, urls := datasetUtils.GetDatasetDetailsPublished(client, APIServer, datasetList)
+		if datasetDetails == nil && urls == nil {
+			fmt.Println("No dataset details were retrieved.")
+		}
 
 		// assemble rsync commands to be submitted
 		batchCommands := assembleRsyncCommands(datasetDetails)

--- a/cmd/commands/datasetPublishDataRetrieve.go
+++ b/cmd/commands/datasetPublishDataRetrieve.go
@@ -109,7 +109,10 @@ var datasetPublishDataRetrieveCmd = &cobra.Command{
 		}
 
 		// get sourceFolder and other dataset related info for all Datasets and print them
-		datasetUtils.GetDatasetDetailsPublished(client, APIServer, datasetList)
+		datasetDetails, urls := datasetUtils.GetDatasetDetailsPublished(client, APIServer, datasetList)
+		if datasetDetails == nil && urls == nil {
+			fmt.Println("No dataset details were retrieved.")
+		}
 
 		if !retrieveFlag {
 			color.Set(color.FgRed)

--- a/datasetUtils/getDatasetDetailsPublished_test.go
+++ b/datasetUtils/getDatasetDetailsPublished_test.go
@@ -14,18 +14,60 @@ func TestGetDatasetDetailsPublished(t *testing.T) {
 		rw.Write([]byte(`[{"pid": "1", "sourceFolder": "/folder1", "size": 100, "ownerGroup": "group1", "numberOfFiles": 10}]`))
 	}))
 	defer server.Close()
-	
+
 	// Create a new HTTP client
 	client := &http.Client{}
-	
+
 	// Call the function with the mock server's URL and a list of dataset IDs
 	datasets, urls := GetDatasetDetailsPublished(client, server.URL, []string{"1"})
-	
+
 	// Test that the function returns the expected results
 	if len(datasets) != 1 || datasets[0].Pid != "1" {
 		t.Errorf("Unexpected datasets: %v", datasets)
 	}
 	if len(urls) != 1 || urls[0] != "https://doi2.psi.ch/datasets/folder1" {
 		t.Errorf("Unexpected URLs: %v", urls)
+	}
+}
+
+func TestGetDatasetDetailsPublished_MissingDatasets(t *testing.T) {
+	// Create a mock HTTP server that returns a list of datasets that does not include all the requested datasets
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte(`[{"pid": "1", "sourceFolder": "/folder1", "size": 100, "ownerGroup": "group1", "numberOfFiles": 10}]`))
+	}))
+	defer server.Close()
+
+	// Create a new HTTP client
+	client := &http.Client{}
+
+	// Call the function with the mock server's URL and a list of dataset IDs
+	datasets, urls := GetDatasetDetailsPublished(client, server.URL, []string{"1", "2"})
+
+	// Since the server does not return details for all the requested datasets, the function should log a message for the missing datasets.
+	// We can't directly test this with the `testing` package
+	if len(datasets) != 1 || datasets[0].Pid != "1" {
+		t.Errorf("Unexpected datasets: %v", datasets)
+	}
+	if len(urls) != 1 || urls[0] != "https://doi2.psi.ch/datasets/folder1" {
+		t.Errorf("Unexpected URLs: %v", urls)
+	}
+}
+
+func TestGetDatasetDetailsPublished_EmptyList(t *testing.T) {
+	// Create a mock HTTP server that always returns an empty list of datasets
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	// Create a new HTTP client
+	client := &http.Client{}
+
+	// Call the function with the mock server's URL and a list of dataset IDs
+	datasets, urls := GetDatasetDetailsPublished(client, server.URL, []string{"1"})
+
+	// Since the server returns an empty list, the function should return empty lists as well
+	if len(datasets) != 0 || len(urls) != 0 {
+		t.Errorf("Expected empty lists, got %v and %v", datasets, urls)
 	}
 }


### PR DESCRIPTION
This PR has the same purpose as PR #66, but is up to date with the current main branch. 

It does not implement the split functions (makeRequest, createFilter, processDatasetDetails) as the code within is specific to the GetDatasetDetailsPublished function. This can be changed, but the functions have to be named something more specific as they will effectively be available in the whole namespace of the DatasetUtils package.

This PR will also close PR #66 . 