### PR TITLE
(fix) split arguments in compatibility scripts before passing to scicat-cli

### DIFF
--- a/cmd/scripts/common.sh
+++ b/cmd/scripts/common.sh
@@ -6,11 +6,12 @@ YEL='\033[1;33m'
 NC='\033[0m' # No Color
 WARN_STRING="${RED}Warning!${YEL} These backwards compatibilty scripts will soon be deprecated!${NC} Please use, or update your code to use, the scicat-cli executable directly."
 
+# Global empty array to hold the modified arguments
+modified_args=()
+
 function arg_conversion {
     args=("$@")
-
-    # Initialize an empty array to hold the modified arguments
-    modified_args=()
+    modified_args=()  # Reset the array for each function call
 
     for arg in "${args[@]}"
     do
@@ -23,6 +24,4 @@ function arg_conversion {
             modified_args+=("$arg")
         fi
     done
-    
-    echo "${modified_args[@]}"
 }

--- a/cmd/scripts/datasetArchiver
+++ b/cmd/scripts/datasetArchiver
@@ -6,5 +6,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR"/common.sh
 
 echo -e "${WARN_STRING}"
-modified_args=$(arg_conversion "$@")
+arg_conversion "$@"
 "$SCRIPT_DIR"/scicat-cli datasetArchiver "${modified_args[@]}"

--- a/cmd/scripts/datasetCleaner
+++ b/cmd/scripts/datasetCleaner
@@ -6,5 +6,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR"/common.sh
 
 echo -e "${WARN_STRING}"
-modified_args=$(arg_conversion "$@")
+arg_conversion "$@"
 "$SCRIPT_DIR"/scicat-cli datasetCleaner "${modified_args[@]}"

--- a/cmd/scripts/datasetGetProposal
+++ b/cmd/scripts/datasetGetProposal
@@ -6,5 +6,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR"/common.sh
 
 echo -e "${WARN_STRING}"
-modified_args=$(arg_conversion "$@")
+arg_conversion "$@"
 "$SCRIPT_DIR"/scicat-cli datasetGetProposal "${modified_args[@]}"

--- a/cmd/scripts/datasetIngestor
+++ b/cmd/scripts/datasetIngestor
@@ -6,5 +6,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR"/common.sh
 
 echo -e "${WARN_STRING}"
-modified_args=$(arg_conversion "$@")
+arg_conversion "$@"
 "$SCRIPT_DIR"/scicat-cli datasetIngestor "${modified_args[@]}"

--- a/cmd/scripts/datasetPublishData
+++ b/cmd/scripts/datasetPublishData
@@ -6,5 +6,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR"/common.sh
 
 echo -e "${WARN_STRING}"
-modified_args=$(arg_conversion "$@")
+arg_conversion "$@"
 "$SCRIPT_DIR"/scicat-cli datasetPublishData "${modified_args[@]}"

--- a/cmd/scripts/datasetPublishDataRetrieve
+++ b/cmd/scripts/datasetPublishDataRetrieve
@@ -6,5 +6,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR"/common.sh
 
 echo -e "${WARN_STRING}"
-modified_args=$(arg_conversion "$@")
+arg_conversion "$@"
 "$SCRIPT_DIR"/scicat-cli datasetPublishDataRetrieve "${modified_args[@]}"

--- a/cmd/scripts/datasetRetriever
+++ b/cmd/scripts/datasetRetriever
@@ -6,5 +6,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR"/common.sh
 
 echo -e "${WARN_STRING}"
-modified_args=$(arg_conversion "$@")
+arg_conversion "$@"
 "$SCRIPT_DIR"/scicat-cli datasetRetriever "${modified_args[@]}"

--- a/cmd/scripts/waitForJobFinished
+++ b/cmd/scripts/waitForJobFinished
@@ -6,5 +6,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$SCRIPT_DIR"/common.sh
 
 echo -e "${WARN_STRING}"
-modified_args=$(arg_conversion "$@")
+arg_conversion "$@"
 "$SCRIPT_DIR"/scicat-cli waitForJobFinished "${modified_args[@]}"


### PR DESCRIPTION
Fixes https://github.com/paulscherrerinstitute/scicat-cli/issues/136

### Fix
In the compatibility scripts, instead of passing the output of `arg_conversion` via `stdout` as a string, we just pass it with a global variable `modified_args` (an array).

### Testing
Tested that arguments are properly passed to scicat-cli with `datasetIngestor` and `datasetRetriever`.
```bash
[zade_o@pc17165 scripts]$ ./datasetIngestor --token=$SCICAT_TOKEN --devenv --ingest metadata.json
Warning! These backwards compatibilty scripts will soon be deprecated! Please use, or update your code to use, the scicat-cli executable directly.
2025/10/01 12:57:59 Warning: Illegal version number:
2025/10/01 12:57:59 Latest version: 2.2.2
2025/10/01 12:57:59 You should upgrade to a newer version
2025/10/01 12:57:59 Current Version: 
2025/10/01 12:57:59 Latest  Version: 2.2.2
2025/10/01 12:57:59 You can find the download instructions here: https://github.com/paulscherrerinstitute/scicat-cli?tab=readme-ov-file#manual-deployment-and-upgrade
2025/10/01 12:57:59 You are about to add a dataset to the === dev === data catalog environment...
2025/10/01 12:57:59 unable to login with token. https://scicat.development.psi.ch/api/v3/users/my/self returned 401 - 'Unauthenticated'
```