### PR TITLE
(fix) use correct endpoint and payload for PATCH datasetlifecycle

### DIFF
--- a/datasetIngestor/markFilesReady.go
+++ b/datasetIngestor/markFilesReady.go
@@ -9,7 +9,7 @@ import (
 )
 
 /*
-MarkFilesReady is a function that sends a PUT request to a specified API server to update the dataset lifecycle status.
+MarkFilesReady is a function that sends a PATCH request to a specified API server to update the dataset lifecycle status.
 
 Parameters:
 - client: An *http.Client object, used to send the HTTP request.
@@ -18,7 +18,7 @@ Parameters:
 - user: A map[string]string containing user information, specifically the access token.
 
 The function constructs a metadata map with the dataset lifecycle status set to "datasetCreated" and archivable set to true.
-This metadata is then converted to JSON and sent in the body of the PUT request.
+This metadata is then converted to JSON and sent in the body of the PATCH request.
 The URL for the request is constructed using the APIServer and datasetId parameters, and the user's access token is appended as a query parameter.
 
 If the request is successful (HTTP status code 200), the function logs a success message along with the response body.
@@ -26,14 +26,13 @@ If the request fails, the function logs a failure message along with the status 
 */
 func MarkFilesReady(client *http.Client, APIServer string, datasetId string, user map[string]string) error {
 	var metaDataMap = map[string]interface{}{}
-	metaDataMap["datasetlifecycle"] = map[string]interface{}{}
-	metaDataMap["datasetlifecycle"].(map[string]interface{})["archiveStatusMessage"] = "datasetCreated"
-	metaDataMap["datasetlifecycle"].(map[string]interface{})["archivable"] = true
+	metaDataMap["archiveStatusMessage"] = "datasetCreated"
+	metaDataMap["archivable"] = true
 
 	cmm, _ := json.Marshal(metaDataMap)
 	// metadataString := string(cmm)
 
-	myurl := APIServer + "/Datasets/" + url.QueryEscape(datasetId)
+	myurl := APIServer + "/Datasets/" + url.QueryEscape(datasetId) + "/datasetlifecycle"
 	req, err := http.NewRequest("PATCH", myurl, bytes.NewBuffer(cmm))
 	if err != nil {
 		return err

--- a/datasetIngestor/markFilesReady_test.go
+++ b/datasetIngestor/markFilesReady_test.go
@@ -12,8 +12,8 @@ func TestSendFilesReadyCommand(t *testing.T) {
 	// Create a mock server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Test method and path
-		if req.URL.String() != "/Datasets/testDatasetId" {
-			t.Errorf("Expected URL '/Datasets/testDatasetId', got '%s'", req.URL.String())
+		if req.URL.String() != "/Datasets/testDatasetId/datasetlifecycle" {
+			t.Errorf("Expected URL '/Datasets/testDatasetId/datasetlifecycle', got '%s'", req.URL.String())
 		}
 		if req.Method != "PATCH" {
 			t.Errorf("Expected method 'PATCH', got '%s'", req.Method)
@@ -29,7 +29,7 @@ func TestSendFilesReadyCommand(t *testing.T) {
 
 		// Test body
 		body, _ := io.ReadAll(req.Body)
-		expectedBody := `{"datasetlifecycle":{"archivable":true,"archiveStatusMessage":"datasetCreated"}}`
+		expectedBody := `{"archivable":true,"archiveStatusMessage":"datasetCreated"}`
 		if strings.TrimSpace(string(body)) != expectedBody {
 			t.Errorf("Expected body '%s', got '%s'", expectedBody, strings.TrimSpace(string(body)))
 		}


### PR DESCRIPTION
Fixes https://github.com/paulscherrerinstitute/scicat-cli/issues/139

Tested that the end-to-end behavior of decentral ingest using `datasetIngestor` is now correct - `isOnCentralDisk` remains false at the end of the process.