### PR TITLE
Add nfpms configuration for scicat-cli RPM (#158)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -129,3 +129,13 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+nfpms:
+  - id: scicat-cli-rpm
+    formats:
+      - rpm
+    package_name: scicat-cli
+    section: default
+
+release:
+  prerelease: auto


### PR DESCRIPTION
`old_be` is the branch checked-out at tag v2.2.2