### PR TITLE
feat: implement remove command

### DIFF
--- a/cmd/cliutils/deleteRunner.go
+++ b/cmd/cliutils/deleteRunner.go
@@ -1,0 +1,74 @@
+package cliutils
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+)
+
+// IngestorConfig holds all the setup parameters
+type IngestorConfig struct {
+	Userpass          string
+	Token             string
+	ScicatUrl         string
+	Testenv           bool
+	Devenv            bool
+	Oidc              bool
+	RequireArchiveMgr bool
+	NonInteractive    bool
+	RemoveFromCatalog bool
+	PID               string
+	DeletionCode      string
+	DeletionReason    string
+}
+
+func RunDeletion(client *http.Client, cfg IngestorConfig, version string, cmdName string) error {
+	// 1. Version and Availability Checks
+	datasetUtils.CheckForNewVersion(client, cmdName, version)
+	datasetUtils.CheckForServiceAvailability(client, cfg.Testenv, true)
+
+	// 2. Resolve API Server
+	config := InputEnvironmentConfig{
+		TestenvFlag: cfg.Testenv,
+		DevenvFlag:  cfg.Devenv,
+		ScicatUrl:   cfg.ScicatUrl,
+	}
+
+	apiServer := config.ResolveAPIServer()
+
+	// 3. Authenticate
+	user, _, err := Authenticate(RealAuthenticator{}, client, apiServer, cfg.Userpass, cfg.Token, cfg.Oidc)
+	if err != nil {
+		return err
+	}
+
+	if cfg.RequireArchiveMgr && user["username"] != "archiveManager" {
+		return fmt.Errorf("permission denied: must be archiveManager")
+	}
+
+	// 4. Execution Logic
+	log.Printf("Starting Archive Removal for PID: %s", cfg.PID)
+	jobID, err := datasetUtils.RemoveFromArchive(client, apiServer, cfg.PID, user, cfg.NonInteractive, datasetUtils.JobParamsStruct{
+		DeletionCode:   datasetUtils.DeletionCode(cfg.DeletionCode),
+		DeletionReason: cfg.DeletionReason,
+	})
+	if err != nil {
+		if jobID != "" {
+			datasetUtils.PatchJobStatus(client, apiServer, user, jobID, string(datasetUtils.JobFailed))
+		}
+		return err
+	}
+
+	// 5. Optional Catalog Removal
+	if cfg.RemoveFromCatalog {
+		err = datasetUtils.RemoveFromCatalog(client, apiServer, cfg.PID, jobID, user, cfg.NonInteractive)
+		if err != nil {
+			datasetUtils.PatchJobStatus(client, apiServer, user, jobID, string(datasetUtils.JobFailed))
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/cliutils/deleteRunner.go
+++ b/cmd/cliutils/deleteRunner.go
@@ -5,70 +5,120 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/fatih/color"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
 )
 
-// IngestorConfig holds all the setup parameters
-type IngestorConfig struct {
-	Userpass          string
-	Token             string
-	ScicatUrl         string
-	Testenv           bool
-	Devenv            bool
-	Oidc              bool
-	RequireArchiveMgr bool
-	NonInteractive    bool
-	RemoveFromCatalog bool
-	PID               string
-	DeletionCode      string
-	DeletionReason    string
+type BaseConfig struct {
+	EnvConfig      InputEnvironmentConfig
+	Userpass       string
+	Token          string
+	Oidc           bool
+	NonInteractive bool
+	HttpClient     *http.Client
+
+	apiServer string
+	user      map[string]string
 }
 
-func RunDeletion(client *http.Client, cfg IngestorConfig, version string, cmdName string) error {
-	// 1. Version and Availability Checks
-	datasetUtils.CheckForNewVersion(client, cmdName, version)
-	datasetUtils.CheckForServiceAvailability(client, cfg.Testenv, true)
+type CleanConfig struct {
+	BaseConfig
+	RemoveFromCatalog bool
+}
 
-	// 2. Resolve API Server
-	config := InputEnvironmentConfig{
-		TestenvFlag: cfg.Testenv,
-		DevenvFlag:  cfg.Devenv,
-		ScicatUrl:   cfg.ScicatUrl,
+type RemoveConfig struct {
+	BaseConfig
+	DeletionCode   string
+	DeletionReason string
+}
+
+// authenticate resolves the environment and logs the user in.
+func (c *BaseConfig) authenticate() error {
+	// Resolve API Server
+	envConfig := InputEnvironmentConfig{
+		TestenvFlag: c.EnvConfig.TestenvFlag,
+		DevenvFlag:  c.EnvConfig.DevenvFlag,
+		ScicatUrl:   c.EnvConfig.ScicatUrl,
 	}
+	c.apiServer = envConfig.ResolveAPIServer()
 
-	apiServer := config.ResolveAPIServer()
-
-	// 3. Authenticate
-	user, _, err := Authenticate(RealAuthenticator{}, client, apiServer, cfg.Userpass, cfg.Token, cfg.Oidc)
+	// Authenticate
+	user, _, err := Authenticate(RealAuthenticator{}, c.HttpClient, c.apiServer, c.Userpass, c.Token, c.Oidc)
 	if err != nil {
 		return err
 	}
+	c.user = user
+	return nil
+}
 
-	if cfg.RequireArchiveMgr && user["username"] != "archiveManager" {
+// runCommonDeletion handles version checks and the core archive removal call.
+func (c *BaseConfig) runCommonDeletion(pid string, version, cmdName string, params datasetUtils.JobParamsStruct) (string, error) {
+	// Version and Availability Checks
+	datasetUtils.CheckForNewVersion(c.HttpClient, cmdName, version)
+	datasetUtils.CheckForServiceAvailability(c.HttpClient, c.EnvConfig.TestenvFlag, true)
+
+	log.Printf("Starting Archive Removal for PID: %s", pid)
+
+	// Execute core archive removal
+	jobID, err := datasetUtils.RemoveFromArchive(c.HttpClient, c.apiServer, pid, c.user, c.NonInteractive, params)
+	if err != nil {
+		if jobID != "" {
+			datasetUtils.PatchJobStatus(c.HttpClient, c.apiServer, c.user, jobID, string(datasetUtils.JobFailed))
+		}
+		return "", err
+	}
+
+	return jobID, err
+}
+
+// --- 2. Exposed Methods ---
+
+// RunFullRemoval handles Auth -> User Check -> Archive Removal -> Catalog Removal.
+func (c *CleanConfig) RunFullRemoval(pid string, version, cmdName string) error {
+	// 1. Authenticate and verify user
+	err := c.authenticate()
+	if err != nil {
+		return err
+	}
+	// Immediate User Check
+	if c.user["username"] != "archiveManager" {
 		return fmt.Errorf("permission denied: must be archiveManager")
 	}
 
-	// 4. Execution Logic
-	log.Printf("Starting Archive Removal for PID: %s", cfg.PID)
-	jobID, err := datasetUtils.RemoveFromArchive(client, apiServer, cfg.PID, user, cfg.NonInteractive, datasetUtils.JobParamsStruct{
-		DeletionCode:   datasetUtils.DeletionCode(cfg.DeletionCode),
-		DeletionReason: cfg.DeletionReason,
-	})
+	// 2. Run the deletion engine
+	jobID, err := c.runCommonDeletion(pid, version, cmdName, datasetUtils.JobParamsStruct{})
 	if err != nil {
-		if jobID != "" {
-			datasetUtils.PatchJobStatus(client, apiServer, user, jobID, string(datasetUtils.JobFailed))
-		}
 		return err
 	}
 
-	// 5. Optional Catalog Removal
-	if cfg.RemoveFromCatalog {
-		err = datasetUtils.RemoveFromCatalog(client, apiServer, cfg.PID, jobID, user, cfg.NonInteractive)
+	if c.RemoveFromCatalog {
+		err = datasetUtils.RemoveFromCatalog(c.HttpClient, c.apiServer, pid, jobID, c.user, c.NonInteractive)
 		if err != nil {
-			datasetUtils.PatchJobStatus(client, apiServer, user, jobID, string(datasetUtils.JobFailed))
+			datasetUtils.PatchJobStatus(c.HttpClient, c.apiServer, c.user, jobID, string(datasetUtils.JobFailed))
 			return err
 		}
 	}
 
+	color.Cyan("Full removal process completed successfully.")
+	return nil
+}
+
+// RunArchiveOnlyRemoval triggers the flow without the catalog step.
+func (c *RemoveConfig) RunArchiveOnlyRemoval(pid string, version, cmdName string) error {
+	// 1. Authenticate and verify user
+	err := c.authenticate()
+	if err != nil {
+		return err
+	}
+
+	// 2. Run the deletion engine
+	jobID, err := c.runCommonDeletion(pid, version, cmdName, datasetUtils.JobParamsStruct{
+		DeletionCode:   datasetUtils.DeletionCode(c.DeletionCode),
+		DeletionReason: c.DeletionReason,
+	})
+	if err != nil {
+		return err
+	}
+	color.Cyan("Archive removal job submitted (JobID: %s).", jobID)
 	return nil
 }

--- a/cmd/cliutils/deleteRunner_test.go
+++ b/cmd/cliutils/deleteRunner_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
 )
 
-func TestRunDeletionSuccessSubmitsResetJob(t *testing.T) {
+func TestRunArchiveOnlyRemovalSuccess(t *testing.T) {
 	t.Setenv("TEST_MODE", "true")
 	oldAvailabilityURL := datasetUtils.GitHubMainLocation
 	t.Cleanup(func() {
@@ -20,26 +20,23 @@ func TestRunDeletionSuccessSubmitsResetJob(t *testing.T) {
 	var postedJob map[string]interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/cmd/datasetIngestor/datasetIngestorServiceAvailability.yml":
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "ServiceAvailability.yml"):
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("Production:\n  Ingest:\n    status: on\n  Archive:\n    status: on\nQa:\n  Ingest:\n    status: on\n  Archive:\n    status: on\n"))
+			_, _ = w.Write([]byte("Production:\n  Ingest:\n    status: on\n  Archive:\n    status: on\n"))
 		case r.Method == http.MethodGet && r.URL.Path == "/users/my/self":
-			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"id":"u1"}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/users/u1/userIdentity":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"profile":{"username":"archiveManager","displayName":"Archivist","accessGroups":["group-a"],"emails":[{"value":"archive@example.com"}]}}`))
+			_, _ = w.Write([]byte(`{"profile":{"username":"aUser","emails":[{"value":"aUser@example.com"}]}}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/Datablocks":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"id":"db1","size":10}]`))
+			_, _ = w.Write([]byte(`[{"id":"db1"}]`))
 		case r.Method == http.MethodPost && r.URL.Path == "/Jobs":
 			defer r.Body.Close()
 			if err := json.NewDecoder(r.Body).Decode(&postedJob); err != nil {
-				t.Fatalf("decode request body: %v", err)
+				t.Fatalf("failed to decode posted job: %v", err)
 			}
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"job-123","jobStatusMessage":"jobSubmitted"}`))
+			_, _ = w.Write([]byte(`{"id":"job-123"}`))
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -48,87 +45,147 @@ func TestRunDeletionSuccessSubmitsResetJob(t *testing.T) {
 
 	datasetUtils.GitHubMainLocation = server.URL
 
-	cfg := IngestorConfig{
-		Token:             "token-abc",
-		ScicatUrl:         server.URL,
-		RequireArchiveMgr: true,
-		NonInteractive:    true,
-		PID:               "pid-001",
-		DeletionCode:      string(datasetUtils.CodeExpired),
-		DeletionReason:    "retention elapsed",
+	cfg := RemoveConfig{
+		BaseConfig: BaseConfig{
+			Token:      "token-abc",
+			HttpClient: server.Client(),
+			EnvConfig: InputEnvironmentConfig{
+				ScicatUrl: server.URL,
+			},
+			NonInteractive: true,
+		},
+		DeletionCode:   string(datasetUtils.CodeExpired),
+		DeletionReason: "retention elapsed",
 	}
 
-	err := RunDeletion(server.Client(), cfg, "0.0.0", "datasetRemover")
+	err := cfg.RunArchiveOnlyRemoval("pid-001", "0.0.0", "datasetRemover")
 	if err != nil {
-		t.Fatalf("RunDeletion returned error: %v", err)
+		t.Fatalf("RunArchiveOnlyRemoval returned error: %v", err)
 	}
 
 	if postedJob == nil {
-		t.Fatal("expected reset job submission payload")
+		t.Fatal("expected job submission payload")
 	}
 
 	jobParams, ok := postedJob["jobParams"].(map[string]interface{})
 	if !ok {
-		t.Fatalf("expected jobParams map in payload, got: %#v", postedJob["jobParams"])
-	}
-	if got := jobParams["username"]; got != "archiveManager" {
-		t.Fatalf("expected username archiveManager, got: %v", got)
+		t.Fatalf("expected jobParams map, got %#v", postedJob["jobParams"])
 	}
 	if got := jobParams["deletionCode"]; got != string(datasetUtils.CodeExpired) {
 		t.Fatalf("expected deletionCode %s, got: %v", datasetUtils.CodeExpired, got)
 	}
 	if got := jobParams["deletionReason"]; got != "retention elapsed" {
-		t.Fatalf("expected deletionReason to be propagated, got: %v", got)
+		t.Fatalf("expected deletionReason retention elapsed, got: %v", got)
 	}
 }
 
-func TestRunDeletionRejectsNonArchiveManager(t *testing.T) {
+func TestRunFullRemoval(t *testing.T) {
 	t.Setenv("TEST_MODE", "true")
 	oldAvailabilityURL := datasetUtils.GitHubMainLocation
 	t.Cleanup(func() {
 		datasetUtils.GitHubMainLocation = oldAvailabilityURL
 	})
 
-	datablocksCalled := false
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/cmd/datasetIngestor/datasetIngestorServiceAvailability.yml":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("Production:\n  Ingest:\n    status: on\n  Archive:\n    status: on\n"))
-		case r.Method == http.MethodGet && r.URL.Path == "/users/my/self":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"id":"u2"}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/users/u2/userIdentity":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"profile":{"username":"normalUser","displayName":"User","accessGroups":[],"emails":[{"value":"user@example.com"}]}}`))
-		case r.URL.Path == "/Datablocks":
-			datablocksCalled = true
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[]`))
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	datasetUtils.GitHubMainLocation = server.URL
-
-	err := RunDeletion(server.Client(), IngestorConfig{
-		Token:             "token-xyz",
-		ScicatUrl:         server.URL,
-		RequireArchiveMgr: true,
-		NonInteractive:    true,
-		PID:               "pid-002",
-	}, "0.0.0", "datasetCleaner")
-
-	if err == nil {
-		t.Fatal("expected permission denied error")
+	testCases := []struct {
+		name              string
+		username          string
+		removeFromCatalog bool
+		expectError       string
+		wantArchive       bool
+		wantCatalog       bool
+	}{
+		{
+			name:              "Error: Not an Archive Manager",
+			username:          "normalUser",
+			removeFromCatalog: true,
+			expectError:       "permission denied",
+			wantArchive:       false,
+			wantCatalog:       false,
+		},
+		{
+			name:              "Success: Archive Only",
+			username:          "archiveManager",
+			removeFromCatalog: false,
+			expectError:       "",
+			wantArchive:       true,
+			wantCatalog:       false,
+		},
+		{
+			name:              "Success: Full Removal",
+			username:          "archiveManager",
+			removeFromCatalog: true,
+			expectError:       "",
+			wantArchive:       true,
+			wantCatalog:       true,
+		},
 	}
-	if !strings.Contains(err.Error(), "permission denied") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if datablocksCalled {
-		t.Fatal("expected early return before querying datablocks")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var archiveCalled, catalogCalled bool
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.HasSuffix(r.URL.Path, "ServiceAvailability.yml"):
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("Production:\n  Ingest:\n    status: on\n  Archive:\n    status: on\n"))
+				case r.URL.Path == "/users/my/self":
+					_, _ = w.Write([]byte(`{"id":"u1"}`))
+				case r.URL.Path == "/users/u1/userIdentity":
+					_, _ = w.Write([]byte(`{"profile":{"username":"` + tc.username + `","emails":[{"value":"archive@example.com"}]}}`))
+				case r.Method == http.MethodGet && r.URL.Path == "/Datablocks":
+					_, _ = w.Write([]byte(`[{"id":"db1"}]`))
+				case r.Method == http.MethodPost && r.URL.Path == "/Jobs":
+					archiveCalled = true
+					_, _ = w.Write([]byte(`{"id":"job-1","jobStatusMessage":"jobSubmitted"}`))
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/origdatablocks/count"):
+					_, _ = w.Write([]byte(`{"count":1}`))
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/attachments/count"):
+					_, _ = w.Write([]byte(`{"count":1}`))
+				case r.Method == http.MethodGet && r.URL.Path == "/Datasets/count":
+					_, _ = w.Write([]byte(`{"count":1}`))
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/datablocks/count"):
+					_, _ = w.Write([]byte(`{"count":0}`))
+				case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/Jobs/"):
+					_, _ = w.Write([]byte(`{"id":"job-1","jobStatusMessage":"finishedSuccessful"}`))
+				case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/Datasets/"):
+					catalogCalled = true
+					w.WriteHeader(http.StatusOK)
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			datasetUtils.GitHubMainLocation = server.URL
+
+			cfg := CleanConfig{
+				BaseConfig: BaseConfig{
+					Token:          "token-abc",
+					HttpClient:     server.Client(),
+					EnvConfig:      InputEnvironmentConfig{ScicatUrl: server.URL},
+					NonInteractive: true,
+				},
+				RemoveFromCatalog: tc.removeFromCatalog,
+			}
+
+			err := cfg.RunFullRemoval("pid-123", "0.0.0", "test")
+
+			if tc.expectError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expectError) {
+					t.Fatalf("expected error %q, got %v", tc.expectError, err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if archiveCalled != tc.wantArchive {
+				t.Errorf("Archive call mismatch: got %v, want %v", archiveCalled, tc.wantArchive)
+			}
+			if catalogCalled != tc.wantCatalog {
+				t.Errorf("Catalog call mismatch: got %v, want %v", catalogCalled, tc.wantCatalog)
+			}
+		})
 	}
 }

--- a/cmd/cliutils/deleteRunner_test.go
+++ b/cmd/cliutils/deleteRunner_test.go
@@ -1,0 +1,134 @@
+package cliutils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+)
+
+func TestRunDeletionSuccessSubmitsResetJob(t *testing.T) {
+	t.Setenv("TEST_MODE", "true")
+	oldAvailabilityURL := datasetUtils.GitHubMainLocation
+	t.Cleanup(func() {
+		datasetUtils.GitHubMainLocation = oldAvailabilityURL
+	})
+
+	var postedJob map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/cmd/datasetIngestor/datasetIngestorServiceAvailability.yml":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Production:\n  Ingest:\n    status: on\n  Archive:\n    status: on\nQa:\n  Ingest:\n    status: on\n  Archive:\n    status: on\n"))
+		case r.Method == http.MethodGet && r.URL.Path == "/users/my/self":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"u1"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/users/u1/userIdentity":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"profile":{"username":"archiveManager","displayName":"Archivist","accessGroups":["group-a"],"emails":[{"value":"archive@example.com"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/Datablocks":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"db1","size":10}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/Jobs":
+			defer r.Body.Close()
+			if err := json.NewDecoder(r.Body).Decode(&postedJob); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"job-123","jobStatusMessage":"jobSubmitted"}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	datasetUtils.GitHubMainLocation = server.URL
+
+	cfg := IngestorConfig{
+		Token:             "token-abc",
+		ScicatUrl:         server.URL,
+		RequireArchiveMgr: true,
+		NonInteractive:    true,
+		PID:               "pid-001",
+		DeletionCode:      string(datasetUtils.CodeExpired),
+		DeletionReason:    "retention elapsed",
+	}
+
+	err := RunDeletion(server.Client(), cfg, "0.0.0", "datasetRemover")
+	if err != nil {
+		t.Fatalf("RunDeletion returned error: %v", err)
+	}
+
+	if postedJob == nil {
+		t.Fatal("expected reset job submission payload")
+	}
+
+	jobParams, ok := postedJob["jobParams"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected jobParams map in payload, got: %#v", postedJob["jobParams"])
+	}
+	if got := jobParams["username"]; got != "archiveManager" {
+		t.Fatalf("expected username archiveManager, got: %v", got)
+	}
+	if got := jobParams["deletionCode"]; got != string(datasetUtils.CodeExpired) {
+		t.Fatalf("expected deletionCode %s, got: %v", datasetUtils.CodeExpired, got)
+	}
+	if got := jobParams["deletionReason"]; got != "retention elapsed" {
+		t.Fatalf("expected deletionReason to be propagated, got: %v", got)
+	}
+}
+
+func TestRunDeletionRejectsNonArchiveManager(t *testing.T) {
+	t.Setenv("TEST_MODE", "true")
+	oldAvailabilityURL := datasetUtils.GitHubMainLocation
+	t.Cleanup(func() {
+		datasetUtils.GitHubMainLocation = oldAvailabilityURL
+	})
+
+	datablocksCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/cmd/datasetIngestor/datasetIngestorServiceAvailability.yml":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Production:\n  Ingest:\n    status: on\n  Archive:\n    status: on\n"))
+		case r.Method == http.MethodGet && r.URL.Path == "/users/my/self":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"u2"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/users/u2/userIdentity":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"profile":{"username":"normalUser","displayName":"User","accessGroups":[],"emails":[{"value":"user@example.com"}]}}`))
+		case r.URL.Path == "/Datablocks":
+			datablocksCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	datasetUtils.GitHubMainLocation = server.URL
+
+	err := RunDeletion(server.Client(), IngestorConfig{
+		Token:             "token-xyz",
+		ScicatUrl:         server.URL,
+		RequireArchiveMgr: true,
+		NonInteractive:    true,
+		PID:               "pid-002",
+	}, "0.0.0", "datasetCleaner")
+
+	if err == nil {
+		t.Fatal("expected permission denied error")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if datablocksCalled {
+		t.Fatal("expected early return before querying datablocks")
+	}
+}

--- a/cmd/commands/datasetCleaner.go
+++ b/cmd/commands/datasetCleaner.go
@@ -37,17 +37,23 @@ For further help see "` + cliutils.MANUAL + `"`,
 
 		const CMD = "datasetCleaner"
 
+		envConfig := cliutils.InputEnvironmentConfig{
+			TestenvFlag: cliutils.GetCobraBoolFlag(cmd, "testenv"),
+			DevenvFlag:  cliutils.GetCobraBoolFlag(cmd, "devenv"),
+			ScicatUrl:   cliutils.GetCobraStringFlag(cmd, "scicat-url"),
+		}
+
 		// pass parameters
-		ingestorConfig := cliutils.IngestorConfig{
-			Userpass:          cliutils.GetCobraStringFlag(cmd, "user"),
-			Token:             cliutils.GetCobraStringFlag(cmd, "token"),
-			ScicatUrl:         cliutils.GetCobraStringFlag(cmd, "scicat-url"),
-			Testenv:           cliutils.GetCobraBoolFlag(cmd, "testenv"),
-			Devenv:            cliutils.GetCobraBoolFlag(cmd, "devenv"),
-			Oidc:              cliutils.GetCobraBoolFlag(cmd, "oidc"),
-			NonInteractive:    cliutils.GetCobraBoolFlag(cmd, "nonInteractive"),
+		ingestorConfig := cliutils.CleanConfig{
+			BaseConfig: cliutils.BaseConfig{
+				Userpass:       cliutils.GetCobraStringFlag(cmd, "user"),
+				Token:          cliutils.GetCobraStringFlag(cmd, "token"),
+				EnvConfig:      envConfig,
+				Oidc:           cliutils.GetCobraBoolFlag(cmd, "oidc"),
+				NonInteractive: cliutils.GetCobraBoolFlag(cmd, "nonInteractive"),
+				HttpClient:     client,
+			},
 			RemoveFromCatalog: cliutils.GetCobraBoolFlag(cmd, "removeFromCatalog"),
-			RequireArchiveMgr: true,
 		}
 
 		showVersion := cliutils.GetCobraBoolFlag(cmd, "version")
@@ -56,9 +62,9 @@ For further help see "` + cliutils.MANUAL + `"`,
 			datasetUtils.TestFlags(map[string]interface{}{
 				"user":              ingestorConfig.Userpass,
 				"token":             ingestorConfig.Token,
-				"testenv":           ingestorConfig.Testenv,
-				"devenv":            ingestorConfig.Devenv,
-				"scicat-url":        ingestorConfig.ScicatUrl,
+				"testenv":           envConfig.TestenvFlag,
+				"devenv":            envConfig.DevenvFlag,
+				"scicat-url":        envConfig.ScicatUrl,
 				"nonInteractive":    ingestorConfig.NonInteractive,
 				"removeFromCatalog": ingestorConfig.RemoveFromCatalog,
 				"version":           showVersion,
@@ -76,9 +82,8 @@ For further help see "` + cliutils.MANUAL + `"`,
 			log.Println("invalid number of args")
 			return
 		}
-		ingestorConfig.PID = args[0]
 
-		err := cliutils.RunDeletion(client, ingestorConfig, VERSION, CMD)
+		err := ingestorConfig.RunFullRemoval(args[0], VERSION, CMD)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/commands/datasetCleaner.go
+++ b/cmd/commands/datasetCleaner.go
@@ -38,25 +38,29 @@ For further help see "` + cliutils.MANUAL + `"`,
 		const CMD = "datasetCleaner"
 
 		// pass parameters
-		removeFromCatalogFlag, _ := cmd.Flags().GetBool("removeFromCatalog")
-		nonInteractiveFlag, _ := cmd.Flags().GetBool("nonInteractive")
-		testenvFlag, _ := cmd.Flags().GetBool("testenv")
-		devenvFlag, _ := cmd.Flags().GetBool("devenv")
-		scicatUrl, _ := cmd.Flags().GetString("scicat-url")
-		userpass, _ := cmd.Flags().GetString("user")
-		token, _ := cmd.Flags().GetString("token")
-		oidc, _ := cmd.Flags().GetBool("oidc")
-		showVersion, _ := cmd.Flags().GetBool("version")
+		ingestorConfig := cliutils.IngestorConfig{
+			Userpass:          cliutils.GetCobraStringFlag(cmd, "user"),
+			Token:             cliutils.GetCobraStringFlag(cmd, "token"),
+			ScicatUrl:         cliutils.GetCobraStringFlag(cmd, "scicat-url"),
+			Testenv:           cliutils.GetCobraBoolFlag(cmd, "testenv"),
+			Devenv:            cliutils.GetCobraBoolFlag(cmd, "devenv"),
+			Oidc:              cliutils.GetCobraBoolFlag(cmd, "oidc"),
+			NonInteractive:    cliutils.GetCobraBoolFlag(cmd, "nonInteractive"),
+			RemoveFromCatalog: cliutils.GetCobraBoolFlag(cmd, "removeFromCatalog"),
+			RequireArchiveMgr: true,
+		}
+
+		showVersion := cliutils.GetCobraBoolFlag(cmd, "version")
 
 		if datasetUtils.TestFlags != nil {
 			datasetUtils.TestFlags(map[string]interface{}{
-				"user":              userpass,
-				"token":             token,
-				"testenv":           testenvFlag,
-				"devenv":            devenvFlag,
-				"scicat-url":        scicatUrl,
-				"nonInteractive":    nonInteractiveFlag,
-				"removeFromCatalog": removeFromCatalogFlag,
+				"user":              ingestorConfig.Userpass,
+				"token":             ingestorConfig.Token,
+				"testenv":           ingestorConfig.Testenv,
+				"devenv":            ingestorConfig.Devenv,
+				"scicat-url":        ingestorConfig.ScicatUrl,
+				"nonInteractive":    ingestorConfig.NonInteractive,
+				"removeFromCatalog": ingestorConfig.RemoveFromCatalog,
 				"version":           showVersion,
 			})
 			return
@@ -68,57 +72,18 @@ For further help see "` + cliutils.MANUAL + `"`,
 			return
 		}
 
-		// check for program version only if running interactively
-
-		datasetUtils.CheckForNewVersion(client, CMD, VERSION)
-		datasetUtils.CheckForServiceAvailability(client, testenvFlag, true)
-
-		// configure environment
-		config := cliutils.InputEnvironmentConfig{
-			TestenvFlag: testenvFlag,
-			DevenvFlag:  devenvFlag,
-			ScicatUrl:   scicatUrl,
-		}
-		APIServer := config.ResolveAPIServer()
-
 		if len(args) != 1 {
 			log.Println("invalid number of args")
 			return
 		}
-		pid := args[0]
+		ingestorConfig.PID = args[0]
 
-		user, _, err := cliutils.Authenticate(cliutils.RealAuthenticator{}, client, APIServer, userpass, token, oidc)
+		err := cliutils.RunDeletion(client, ingestorConfig, VERSION, CMD)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		if user["username"] != "archiveManager" {
-			log.Fatalf("You must be archiveManager to be allowed to delete datasets\n")
-		}
-
-		jobID, err := datasetUtils.RemoveFromArchive(client, APIServer, pid, user, nonInteractiveFlag, datasetUtils.JobParamsStruct{})
-		if err != nil {
-			if jobID != "" {
-				patchError := datasetUtils.PatchJobStatus(client, APIServer, user, jobID, string(datasetUtils.JobFailed))
-				if patchError != nil {
-					log.Fatalf("Failed to patch job status: %v", patchError)
-				}
-			}
-			log.Fatal(err)
-		}
-
-		if removeFromCatalogFlag {
-			err = datasetUtils.RemoveFromCatalog(client, APIServer, pid, jobID, user, nonInteractiveFlag)
-			if err != nil {
-				if jobID != "" {
-					patchError := datasetUtils.PatchJobStatus(client, APIServer, user, jobID, string(datasetUtils.JobFailed))
-					if patchError != nil {
-						log.Fatalf("Failed to patch job status: %v", patchError)
-					}
-				}
-				log.Fatal(err)
-			}
-		} else {
+		if !ingestorConfig.RemoveFromCatalog {
 			log.Println("To also delete the dataset from the catalog add the flag --removeFromCatalog")
 		}
 	},

--- a/cmd/commands/datasetRemover.go
+++ b/cmd/commands/datasetRemover.go
@@ -38,28 +38,31 @@ For further help see "` + cliutils.MANUAL + `"`,
 		const CMD = "datasetRemover"
 
 		// pass parameters
-		nonInteractiveFlag, _ := cmd.Flags().GetBool("nonInteractive")
-		testenvFlag, _ := cmd.Flags().GetBool("testenv")
-		devenvFlag, _ := cmd.Flags().GetBool("devenv")
-		scicatUrl, _ := cmd.Flags().GetString("scicat-url")
-		userpass, _ := cmd.Flags().GetString("user")
-		token, _ := cmd.Flags().GetString("token")
-		oidc, _ := cmd.Flags().GetBool("oidc")
-		showVersion, _ := cmd.Flags().GetBool("version")
-		deletionCode, _ := cmd.Flags().GetString("deletionCode")
-		deletionReason, _ := cmd.Flags().GetString("deletionReason")
+		ingestorConfig := cliutils.IngestorConfig{
+			Userpass:       cliutils.GetCobraStringFlag(cmd, "user"),
+			Token:          cliutils.GetCobraStringFlag(cmd, "token"),
+			ScicatUrl:      cliutils.GetCobraStringFlag(cmd, "scicat-url"),
+			Testenv:        cliutils.GetCobraBoolFlag(cmd, "testenv"),
+			Devenv:         cliutils.GetCobraBoolFlag(cmd, "devenv"),
+			Oidc:           cliutils.GetCobraBoolFlag(cmd, "oidc"),
+			NonInteractive: cliutils.GetCobraBoolFlag(cmd, "nonInteractive"),
+			DeletionCode:   cliutils.GetCobraStringFlag(cmd, "deletionCode"),
+			DeletionReason: cliutils.GetCobraStringFlag(cmd, "deletionReason"),
+		}
+
+		showVersion := cliutils.GetCobraBoolFlag(cmd, "version")
 
 		if datasetUtils.TestFlags != nil {
 			datasetUtils.TestFlags(map[string]interface{}{
-				"user":           userpass,
-				"token":          token,
-				"testenv":        testenvFlag,
-				"devenv":         devenvFlag,
-				"scicat-url":     scicatUrl,
-				"nonInteractive": nonInteractiveFlag,
+				"user":           ingestorConfig.Userpass,
+				"token":          ingestorConfig.Token,
+				"testenv":        ingestorConfig.Testenv,
+				"devenv":         ingestorConfig.Devenv,
+				"scicat-url":     ingestorConfig.ScicatUrl,
+				"nonInteractive": ingestorConfig.NonInteractive,
 				"version":        showVersion,
-				"deletionCode":   deletionCode,
-				"deletionReason": deletionReason,
+				"deletionCode":   ingestorConfig.DeletionCode,
+				"deletionReason": ingestorConfig.DeletionReason,
 			})
 			return
 		}
@@ -70,40 +73,14 @@ For further help see "` + cliutils.MANUAL + `"`,
 			return
 		}
 
-		// check for program version only if running interactively
-
-		datasetUtils.CheckForNewVersion(client, CMD, VERSION)
-		datasetUtils.CheckForServiceAvailability(client, testenvFlag, true)
-
-		// configure environment
-		APIServer := cliutils.ConfigureEnvironment(cliutils.InputEnvironmentConfig{
-			TestenvFlag: testenvFlag,
-			DevenvFlag:  devenvFlag,
-			ScicatUrl:   scicatUrl,
-		})
-
 		if len(args) != 1 {
 			log.Println("invalid number of args")
 			return
 		}
-		pid := args[0]
+		ingestorConfig.PID = args[0]
 
-		user, _, err := cliutils.Authenticate(cliutils.RealAuthenticator{}, client, APIServer, userpass, token, oidc)
+		err := cliutils.RunDeletion(client, ingestorConfig, VERSION, CMD)
 		if err != nil {
-			log.Fatal(err)
-		}
-
-		jobID, err := datasetUtils.RemoveFromArchive(client, APIServer, pid, user, nonInteractiveFlag, datasetUtils.JobParamsStruct{
-			DeletionCode:   datasetUtils.DeletionCode(deletionCode),
-			DeletionReason: deletionReason,
-		})
-		if err != nil {
-			if jobID != "" {
-				patchError := datasetUtils.PatchJobStatus(client, APIServer, user, jobID, string(datasetUtils.JobFailed))
-				if patchError != nil {
-					log.Fatalf("Failed to patch job status: %v", patchError)
-				}
-			}
 			log.Fatal(err)
 		}
 	},
@@ -112,7 +89,6 @@ For further help see "` + cliutils.MANUAL + `"`,
 func init() {
 	rootCmd.AddCommand(datasetRemoverCmd)
 
-	datasetRemoverCmd.Flags().Bool("removeFromCatalog", false, "Defines if the dataset should also be deleted from data catalog")
 	datasetRemoverCmd.Flags().Bool("nonInteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
 	datasetRemoverCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
 	datasetRemoverCmd.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")

--- a/cmd/commands/datasetRemover.go
+++ b/cmd/commands/datasetRemover.go
@@ -38,14 +38,19 @@ For further help see "` + cliutils.MANUAL + `"`,
 		const CMD = "datasetRemover"
 
 		// pass parameters
-		ingestorConfig := cliutils.IngestorConfig{
-			Userpass:       cliutils.GetCobraStringFlag(cmd, "user"),
-			Token:          cliutils.GetCobraStringFlag(cmd, "token"),
-			ScicatUrl:      cliutils.GetCobraStringFlag(cmd, "scicat-url"),
-			Testenv:        cliutils.GetCobraBoolFlag(cmd, "testenv"),
-			Devenv:         cliutils.GetCobraBoolFlag(cmd, "devenv"),
-			Oidc:           cliutils.GetCobraBoolFlag(cmd, "oidc"),
-			NonInteractive: cliutils.GetCobraBoolFlag(cmd, "nonInteractive"),
+		ingestorConfig := cliutils.RemoveConfig{
+			BaseConfig: cliutils.BaseConfig{
+				Userpass: cliutils.GetCobraStringFlag(cmd, "user"),
+				Token:    cliutils.GetCobraStringFlag(cmd, "token"),
+				EnvConfig: cliutils.InputEnvironmentConfig{
+					TestenvFlag: cliutils.GetCobraBoolFlag(cmd, "testenv"),
+					DevenvFlag:  cliutils.GetCobraBoolFlag(cmd, "devenv"),
+					ScicatUrl:   cliutils.GetCobraStringFlag(cmd, "scicat-url"),
+				},
+				Oidc:           cliutils.GetCobraBoolFlag(cmd, "oidc"),
+				NonInteractive: cliutils.GetCobraBoolFlag(cmd, "nonInteractive"),
+				HttpClient:     client,
+			},
 			DeletionCode:   cliutils.GetCobraStringFlag(cmd, "deletionCode"),
 			DeletionReason: cliutils.GetCobraStringFlag(cmd, "deletionReason"),
 		}
@@ -56,9 +61,9 @@ For further help see "` + cliutils.MANUAL + `"`,
 			datasetUtils.TestFlags(map[string]interface{}{
 				"user":           ingestorConfig.Userpass,
 				"token":          ingestorConfig.Token,
-				"testenv":        ingestorConfig.Testenv,
-				"devenv":         ingestorConfig.Devenv,
-				"scicat-url":     ingestorConfig.ScicatUrl,
+				"testenv":        ingestorConfig.EnvConfig.TestenvFlag,
+				"devenv":         ingestorConfig.EnvConfig.DevenvFlag,
+				"scicat-url":     ingestorConfig.EnvConfig.ScicatUrl,
 				"nonInteractive": ingestorConfig.NonInteractive,
 				"version":        showVersion,
 				"deletionCode":   ingestorConfig.DeletionCode,
@@ -77,9 +82,8 @@ For further help see "` + cliutils.MANUAL + `"`,
 			log.Println("invalid number of args")
 			return
 		}
-		ingestorConfig.PID = args[0]
 
-		err := cliutils.RunDeletion(client, ingestorConfig, VERSION, CMD)
+		err := ingestorConfig.RunArchiveOnlyRemoval(args[0], VERSION, CMD)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/commands/datasetRemover.go
+++ b/cmd/commands/datasetRemover.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var datasetCleanerCmd = &cobra.Command{
-	Use:   "datasetCleaner [options] datasetPid",
+var datasetRemoverCmd = &cobra.Command{
+	Use:   "datasetRemover [options] datasetPid",
 	Short: "Remove dataset from archive and optionally from data catalog",
 	Long: `Tool to remove datasets from the data catalog.
 	
@@ -35,10 +35,9 @@ For further help see "` + cliutils.MANUAL + `"`,
 			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: false}},
 			Timeout:   10 * time.Second}
 
-		const CMD = "datasetCleaner"
+		const CMD = "datasetRemover"
 
 		// pass parameters
-		removeFromCatalogFlag, _ := cmd.Flags().GetBool("removeFromCatalog")
 		nonInteractiveFlag, _ := cmd.Flags().GetBool("nonInteractive")
 		testenvFlag, _ := cmd.Flags().GetBool("testenv")
 		devenvFlag, _ := cmd.Flags().GetBool("devenv")
@@ -47,17 +46,20 @@ For further help see "` + cliutils.MANUAL + `"`,
 		token, _ := cmd.Flags().GetString("token")
 		oidc, _ := cmd.Flags().GetBool("oidc")
 		showVersion, _ := cmd.Flags().GetBool("version")
+		deletionCode, _ := cmd.Flags().GetString("deletionCode")
+		deletionReason, _ := cmd.Flags().GetString("deletionReason")
 
 		if datasetUtils.TestFlags != nil {
 			datasetUtils.TestFlags(map[string]interface{}{
-				"user":              userpass,
-				"token":             token,
-				"testenv":           testenvFlag,
-				"devenv":            devenvFlag,
-				"scicat-url":        scicatUrl,
-				"nonInteractive":    nonInteractiveFlag,
-				"removeFromCatalog": removeFromCatalogFlag,
-				"version":           showVersion,
+				"user":           userpass,
+				"token":          token,
+				"testenv":        testenvFlag,
+				"devenv":         devenvFlag,
+				"scicat-url":     scicatUrl,
+				"nonInteractive": nonInteractiveFlag,
+				"version":        showVersion,
+				"deletionCode":   deletionCode,
+				"deletionReason": deletionReason,
 			})
 			return
 		}
@@ -74,12 +76,11 @@ For further help see "` + cliutils.MANUAL + `"`,
 		datasetUtils.CheckForServiceAvailability(client, testenvFlag, true)
 
 		// configure environment
-		config := cliutils.InputEnvironmentConfig{
+		APIServer := cliutils.ConfigureEnvironment(cliutils.InputEnvironmentConfig{
 			TestenvFlag: testenvFlag,
 			DevenvFlag:  devenvFlag,
 			ScicatUrl:   scicatUrl,
-		}
-		APIServer := config.ResolveAPIServer()
+		})
 
 		if len(args) != 1 {
 			log.Println("invalid number of args")
@@ -92,11 +93,10 @@ For further help see "` + cliutils.MANUAL + `"`,
 			log.Fatal(err)
 		}
 
-		if user["username"] != "archiveManager" {
-			log.Fatalf("You must be archiveManager to be allowed to delete datasets\n")
-		}
-
-		jobID, err := datasetUtils.RemoveFromArchive(client, APIServer, pid, user, nonInteractiveFlag, datasetUtils.JobParamsStruct{})
+		jobID, err := datasetUtils.RemoveFromArchive(client, APIServer, pid, user, nonInteractiveFlag, datasetUtils.JobParamsStruct{
+			DeletionCode:   datasetUtils.DeletionCode(deletionCode),
+			DeletionReason: deletionReason,
+		})
 		if err != nil {
 			if jobID != "" {
 				patchError := datasetUtils.PatchJobStatus(client, APIServer, user, jobID, string(datasetUtils.JobFailed))
@@ -106,31 +106,18 @@ For further help see "` + cliutils.MANUAL + `"`,
 			}
 			log.Fatal(err)
 		}
-
-		if removeFromCatalogFlag {
-			err = datasetUtils.RemoveFromCatalog(client, APIServer, pid, jobID, user, nonInteractiveFlag)
-			if err != nil {
-				if jobID != "" {
-					patchError := datasetUtils.PatchJobStatus(client, APIServer, user, jobID, string(datasetUtils.JobFailed))
-					if patchError != nil {
-						log.Fatalf("Failed to patch job status: %v", patchError)
-					}
-				}
-				log.Fatal(err)
-			}
-		} else {
-			log.Println("To also delete the dataset from the catalog add the flag --removeFromCatalog")
-		}
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(datasetCleanerCmd)
+	rootCmd.AddCommand(datasetRemoverCmd)
 
-	datasetCleanerCmd.Flags().Bool("removeFromCatalog", false, "Defines if the dataset should also be deleted from data catalog")
-	datasetCleanerCmd.Flags().Bool("nonInteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
-	datasetCleanerCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
-	datasetCleanerCmd.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")
-
-	datasetCleanerCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
+	datasetRemoverCmd.Flags().Bool("removeFromCatalog", false, "Defines if the dataset should also be deleted from data catalog")
+	datasetRemoverCmd.Flags().Bool("nonInteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
+	datasetRemoverCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
+	datasetRemoverCmd.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")
+	datasetRemoverCmd.Flags().String("deletionCode", "", "Code for the deletion reason")
+	datasetRemoverCmd.Flags().String("deletionReason", "", "Reason for the deletion")
+	datasetRemoverCmd.MarkFlagRequired("deletionCode")
+	datasetRemoverCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
 }

--- a/datasetUtils/removeFromArchive.go
+++ b/datasetUtils/removeFromArchive.go
@@ -13,6 +13,25 @@ import (
 	"github.com/fatih/color"
 )
 
+type DeletionCode string
+
+const (
+	CodeSuperseded DeletionCode = "SUPERSEDED"
+	CodeExpired    DeletionCode = "EXPIRED"
+	CodeRemoved    DeletionCode = "REMOVED"
+	CodeUnknown    DeletionCode = ""
+)
+
+var AllDeletionCodes = []DeletionCode{CodeSuperseded, CodeExpired, CodeRemoved}
+
+func (c DeletionCode) IsValid() bool {
+	switch c {
+	case CodeSuperseded, CodeExpired, CodeRemoved:
+		return true
+	}
+	return false
+}
+
 type datablockInfo struct {
 	ID   string `json:"id"`
 	Size int    `json:"size"`
@@ -23,16 +42,18 @@ type datasetStruct struct {
 	Files []string `json:"files"`
 }
 
-type jobParamsStruct struct {
-	Username string `json:"username"`
+type JobParamsStruct struct {
+	Username       string       `json:"username"`
+	DeletionCode   DeletionCode `json:"deletionCode,omitempty"`
+	DeletionReason string       `json:"deletionReason,omitempty"`
 }
 
 type JobSubmissionResponse struct {
-	ID string `json:"id"`
+	ID               string `json:"id"`
 	JobStatusMessage string `json:"jobStatusMessage"`
 }
 
-func RemoveFromArchive(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool) (string, error) {
+func RemoveFromArchive(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, additionalJobParameters JobParamsStruct) (string, error) {
 	respObj, err := getDatablocks(client, APIServer, pid, user)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch datablocks: %w", err)
@@ -63,7 +84,10 @@ func RemoveFromArchive(client *http.Client, APIServer string, pid string, user m
 	} else {
 		log.Println("Non-interactive mode: proceeding automatically.")
 	}
-	jobMap := buildResetJobMap(pid, user)
+	jobMap, err := buildResetJobMap(pid, user, additionalJobParameters)
+	if err != nil {
+		return "", fmt.Errorf("failed to build reset job map: %w", err)
+	}
 	jobID, err := submitJob(client, APIServer, user, jobMap)
 	if err != nil {
 		return "", fmt.Errorf("archive reset job submission failed: %w", err)
@@ -101,17 +125,21 @@ func getDatablocks(client *http.Client, APIServer string, pid string, user map[s
 	return respObj, nil
 }
 
-func buildResetJobMap(pid string, user map[string]string) map[string]interface{} {
+func buildResetJobMap(pid string, user map[string]string, params JobParamsStruct) (map[string]interface{}, error) {
+	if params.DeletionCode != CodeUnknown && !params.DeletionCode.IsValid() {
+		return nil, fmt.Errorf("invalid deletion code: %s", params.DeletionCode)
+	}
+	params.Username = user["username"]
 	return map[string]interface{}{
 		"emailJobInitiator": user["mail"],
 		"type":              "reset",
 		"creationTime":      time.Now().Format(time.RFC3339),
-		"jobParams":         jobParamsStruct{Username: user["username"]},
+		"jobParams":         params,
 		"jobStatusMessage":  "jobSubmitted",
 		"datasetList": []datasetStruct{
 			{Pid: pid, Files: []string{}},
 		},
-	}
+	}, nil
 }
 
 func submitJob(client *http.Client, APIServer string, user map[string]string, jobMap map[string]interface{}) (string, error) {

--- a/datasetUtils/removeFromArchive.go
+++ b/datasetUtils/removeFromArchive.go
@@ -18,15 +18,15 @@ type DeletionCode string
 const (
 	CodeSuperseded DeletionCode = "SUPERSEDED"
 	CodeExpired    DeletionCode = "EXPIRED"
-	CodeRemoved    DeletionCode = "REMOVED"
+	CodeDeleted    DeletionCode = "DELETED"
 	CodeUnknown    DeletionCode = ""
 )
 
-var AllDeletionCodes = []DeletionCode{CodeSuperseded, CodeExpired, CodeRemoved}
+var AllDeletionCodes = []DeletionCode{CodeSuperseded, CodeExpired, CodeDeleted}
 
 func (c DeletionCode) IsValid() bool {
 	switch c {
-	case CodeSuperseded, CodeExpired, CodeRemoved:
+	case CodeSuperseded, CodeExpired, CodeDeleted:
 		return true
 	}
 	return false

--- a/datasetUtils/removeFromArchive_test.go
+++ b/datasetUtils/removeFromArchive_test.go
@@ -6,44 +6,65 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
-type JobParams struct {
-	Username string `json:"username"`
-}
-
 type Payload struct {
-	EmailJobInitiator string                   `json:"emailJobInitiator"`
-	JobParams         JobParams                `json:"jobParams"`
-	JobStatusMessage  string                   `json:"jobStatusMessage"`
-	DatasetList       []map[string]interface{} `json:"datasetList"`
-	Type              string                   `json:"type"`
+	EmailJobInitiator string          `json:"emailJobInitiator"`
+	JobParams         JobParamsStruct `json:"jobParams"`
+	JobStatusMessage  string          `json:"jobStatusMessage"`
+	DatasetList       []datasetStruct `json:"datasetList"`
+	Type              string          `json:"type"`
 }
 
 func TestRemoveFromArchive(t *testing.T) {
 	tests := []struct {
 		name            string
 		mockResponse    string
-		expectedDataset []map[string]interface{}
+		jobParams       JobParamsStruct
+		expectedDataset []datasetStruct
 		expectedJobID   string
 		expectPost      bool
+		expectError     string
 	}{
 		{
 			name:            "Return empty datablocks list",
 			mockResponse:    `[]`,
-			expectedDataset: []map[string]interface{}{},
+			expectedDataset: []datasetStruct{},
 			expectedJobID:   "",
 			expectPost:      false,
 		},
 		{
 			name:         "Return datablocks list of size 2",
 			mockResponse: `[{"id": "datablock1", "size": 50}, {"id": "datablock2", "size": 100}]`,
-			expectedDataset: []map[string]interface{}{
-				{"pid": "dataset1", "files": []interface{}{}},
+			expectedDataset: []datasetStruct{
+				{Pid: "dataset1", Files: []string{}},
 			},
 			expectedJobID: "123",
 			expectPost:    true,
+		},
+		{
+			name:         "Include deletion metadata in submitted job params",
+			mockResponse: `[{"id": "datablock1", "size": 50}]`,
+			jobParams: JobParamsStruct{
+				DeletionCode:   CodeExpired,
+				DeletionReason: "retention elapsed",
+			},
+			expectedDataset: []datasetStruct{
+				{Pid: "dataset1", Files: []string{}},
+			},
+			expectedJobID: "123",
+			expectPost:    true,
+		},
+		{
+			name:         "Reject invalid deletion code",
+			mockResponse: `[{"id": "datablock1", "size": 50}]`,
+			jobParams: JobParamsStruct{
+				DeletionCode: DeletionCode("NOT_VALID"),
+			},
+			expectError: "invalid deletion code",
+			expectPost:  false,
 		},
 	}
 	user := map[string]string{
@@ -56,13 +77,16 @@ func TestRemoveFromArchive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			expectedPayload := Payload{
 				EmailJobInitiator: "test@example.com",
-				JobParams:         JobParams{Username: "testuser"},
-				JobStatusMessage:  "jobSubmitted",
-				DatasetList:       tt.expectedDataset,
-				Type:              "reset",
+				JobParams: JobParamsStruct{
+					Username:       "testuser",
+					DeletionCode:   tt.jobParams.DeletionCode,
+					DeletionReason: tt.jobParams.DeletionReason,
+				},
+				JobStatusMessage: "jobSubmitted",
+				DatasetList:      tt.expectedDataset,
+				Type:             "reset",
 			}
 
-			// Create a mock HTTP client
 			client := &http.Client{
 				Transport: &MockTransport{
 					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
@@ -74,13 +98,10 @@ func TestRemoveFromArchive(t *testing.T) {
 						}
 
 						if !tt.expectPost {
-							t.Fatalf("unexpected POST request when no datablocks are returned")
+							t.Fatalf("unexpected POST request")
 						}
 
-						body, err := io.ReadAll(req.Body)
-						if err != nil {
-							t.Fatalf("Failed to read request body: %v", err)
-						}
+						body, _ := io.ReadAll(req.Body)
 						defer req.Body.Close()
 
 						var actual map[string]interface{}
@@ -103,7 +124,15 @@ func TestRemoveFromArchive(t *testing.T) {
 				},
 			}
 
-			jobID, err := RemoveFromArchive(client, "http://mockserver", "dataset1", user, true, JobParamsStruct{})
+			jobID, err := RemoveFromArchive(client, "http://mockserver", "dataset1", user, true, tt.jobParams)
+
+			if tt.expectError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.expectError) {
+					t.Fatalf("expected error containing %q, got: %v", tt.expectError, err)
+				}
+				return
+			}
+
 			if err != nil {
 				t.Fatalf("RemoveFromArchive returned unexpected error: %v", err)
 			}

--- a/datasetUtils/removeFromArchive_test.go
+++ b/datasetUtils/removeFromArchive_test.go
@@ -103,7 +103,7 @@ func TestRemoveFromArchive(t *testing.T) {
 				},
 			}
 
-			jobID, err := RemoveFromArchive(client, "http://mockserver", "dataset1", user, true)
+			jobID, err := RemoveFromArchive(client, "http://mockserver", "dataset1", user, true, JobParamsStruct{})
 			if err != nil {
 				t.Fatalf("RemoveFromArchive returned unexpected error: %v", err)
 			}


### PR DESCRIPTION
Adds datasetRemove command that takes PID as an argument and submits an extend job by new jobParams including the reason for deletion. It reuses the logic from datasetCleaner but skips the removeFromCatalogue step to keep track of datasets existence