### PR TITLE
feat: allow for multiple args in datasetIngest

### DIFF
--- a/cmd/commands/args_test.go
+++ b/cmd/commands/args_test.go
@@ -36,10 +36,10 @@ func TestArgs(t *testing.T) {
 			name: "datasetIngestor test with 2 params - filelisting",
 			expectedArgs: []interface{}{
 				"some/place/metadata.json",
-				"/some/path/",
+				"/some/path/filelisting.txt",
 				"",
 			},
-			args: []string{"datasetIngestor", "some/place/metadata.json", "/some/path/"},
+			args: []string{"datasetIngestor", "some/place/metadata.json", "/some/path/filelisting.txt"},
 		},
 	}
 

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -12,16 +12,30 @@ var datasetIngestorCmd = &cobra.Command{
 	Long: `Purpose: define and add a dataset to the SciCat datacatalog
 
 This command must be run on the machine having access to the data
-which comprises the dataset. It takes one or two input
-files and creates the necessary messages which trigger
-the creation of the corresponding datacatalog entries
+which comprises the dataset. It takes one or more arguments and creates
+the necessary messages which trigger the creation of the corresponding
+datacatalog entries.
+
+Argument formats accepted:
+
+  Single dataset (legacy positional form):
+    metadata.json
+    metadata.json filelist.txt
+    metadata.json folderlisting.txt
+
+  Multiple datasets (@ separator form):
+    metadata1.json@filelist1.txt metadata2.json@filelist2.txt ...
+    metadata1.json metadata2.json ...
+
+  In the @ form the right-hand side (filelist.txt) is optional.
+  Omit the @ entirely to pass only the metadata file.
 
 For further help see "` + cliutils.MANUAL + `"
 
 Special hints for the decentral use case, where data is copied first to intermediate storage:
 For Linux you need to have a valid Kerberos tickets, which you can get via the kinit command.
 For Windows you need instead to specify -user username:password on the command line.`,
-	Args: rangeArgsWithVersionException(1, 2),
+	Args: minArgsWithVersionException(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		orchestrator.RunIngestionPipeline(cmd, args, VERSION)
 	},

--- a/cmd/commands/flags_test.go
+++ b/cmd/commands/flags_test.go
@@ -154,7 +154,7 @@ func TestMainFlags(t *testing.T) {
 				"addcaption":          "",
 				"tapecopies":          0,
 			},
-			args: []string{"datasetIngestor", "argument placeholder"},
+			args: []string{"datasetIngestor", "argument_placeholder.json"},
 		},
 		{ // note: the environment flags are mutually exclusive, not all of them can be set at once
 			name: "datasetIngestor test with (almost) all flags set",
@@ -204,7 +204,7 @@ func TestMainFlags(t *testing.T) {
 				"--addcaption",
 				"a seemingly random caption",
 				"--version",
-				"argument placeholder",
+				"argument_placeholder.json",
 			},
 		},
 		// datasetPublishData

--- a/orchestrator/ingest.go
+++ b/orchestrator/ingest.go
@@ -64,6 +64,15 @@ type DatasetArgs struct {
 	AbsFileListing     string
 }
 
+type ingestionResult struct {
+	archivableDatasets []string
+	ownerGroup         string
+	skippedLinks       uint
+	illegalFileNames   uint
+	emptyDatasets      int
+	tooLargeDatasets   int
+}
+
 type FileContext struct {
 	FullFileArray []datasetIngestor.Datafile
 	StartTime     time.Time
@@ -149,6 +158,83 @@ func ParseAndValidateArgs(args []string) (DatasetArgs, error) {
 		}
 	}
 	return dArgs, nil
+}
+
+func ParseAndValidateSeparatorArg(arg string) (DatasetArgs, error) {
+	meta, fileList, _ := strings.Cut(arg, "@")
+	if meta == "" {
+		return DatasetArgs{}, fmt.Errorf("invalid argument %q: metadata file cannot be empty", arg)
+	}
+	if fileList == "" {
+		return ParseAndValidateArgs([]string{meta})
+	}
+	return ParseAndValidateArgs([]string{meta, fileList})
+}
+
+func ParseAndValidateAllArgs(args []string) ([]DatasetArgs, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("no execution arguments provided")
+	}
+
+	for _, arg := range args {
+		if err := ValidateArgumentFormat(arg); err != nil {
+			return nil, err
+		}
+	}
+
+	// Legacy mode: no @ anywhere — delegate to the single/double positional arg parser.
+	if isLegacyMode(args) {
+		singleArg, err := ParseAndValidateArgs(args)
+		if err != nil {
+			return nil, fmt.Errorf("invalid arguments: %w", err)
+		}
+		return []DatasetArgs{singleArg}, nil
+	}
+
+	// @ mode: every arg is "meta.json[:filelist.txt]".
+	allArgs := make([]DatasetArgs, 0, len(args))
+	for i, arg := range args {
+		dArgs, err := ParseAndValidateSeparatorArg(arg)
+		if err != nil {
+			return nil, fmt.Errorf("invalid argument at position %d: %w", i+1, err)
+		}
+		allArgs = append(allArgs, dArgs)
+	}
+	return allArgs, nil
+}
+
+func isLegacyMode(args []string) bool {
+	return len(args) == 2 &&
+		filepath.Ext(args[1]) == ".txt" &&
+		!strings.Contains(args[0], "@") &&
+		!strings.Contains(args[1], "@")
+}
+
+func ValidateArgumentFormat(arg string) error {
+	cleanArg := strings.TrimSpace(arg)
+	if cleanArg == "" {
+		return fmt.Errorf("argument cannot be empty")
+	}
+
+	if left, right, found := strings.Cut(cleanArg, "@"); found {
+		if strings.HasSuffix(cleanArg, "@") {
+			return fmt.Errorf("invalid argument format %q: argument cannot end with @", arg)
+		}
+		if filepath.Ext(left) != ".json" {
+			return fmt.Errorf("invalid format in pair %q: left side must have a .json extension", arg)
+		}
+		if right != "" && filepath.Ext(right) != ".txt" {
+			return fmt.Errorf("invalid format in pair %q: right side must have a .txt extension", arg)
+		}
+		return nil
+	}
+
+	ext := filepath.Ext(cleanArg)
+	if ext == ".json" || ext == ".txt" {
+		return nil
+	}
+
+	return fmt.Errorf("invalid argument format %q: must be 'metadata.json@filelist.txt', '.json', or '.txt'", arg)
 }
 
 func SetupTransferStrategy(cfg IngestConfig) (func(cliutils.TransferParams) (bool, error), globus.GlobusClient, cliutils.GlobusConfig, error) {
@@ -429,6 +515,25 @@ func ExecuteFileTransfer(
 	return archivable
 }
 
+func submitAndPrintResults(ictx IngestContext, user map[string]string, ownerGroup string, archivableDatasets []string) error {
+	for _, id := range archivableDatasets {
+		fmt.Println(id)
+	}
+	if !ictx.Cfg.AutoarchiveFlag || !ictx.Cfg.IngestFlag || len(archivableDatasets) == 0 {
+		return nil
+	}
+	log.Printf("Submitting Archive Job for the ingested datasets.\n")
+	jobId, err := ictx.CreateArchivalJob(ictx.Client, ictx.APIServer, user, ownerGroup, archivableDatasets, &ictx.Cfg.Tapecopies, nil)
+	if err != nil {
+		color.Set(color.FgRed)
+		log.Printf("Could not create the archival job: %s\n", err.Error())
+		color.Unset()
+		return fmt.Errorf("could not create the archival job: %w", err)
+	}
+	log.Println("Submitted job:", jobId)
+	return nil
+}
+
 // RunIngestionPipeline is the Cobra entry point. It wires real implementations
 // into IngestContext and is the only function in this package that calls log.Fatal.
 func RunIngestionPipeline(cmd *cobra.Command, args []string, version string) {
@@ -464,19 +569,18 @@ func RunIngestionPipeline(cmd *cobra.Command, args []string, version string) {
 		AddAttachment:               datasetIngestor.AddAttachment,
 		CreateArchivalJob:           datasetUtils.CreateArchivalJob,
 	}
-	if err := runIngestionPipeline(ctx, args, version); err != nil {
+
+	dArgs, err := ParseAndValidateAllArgs(args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := runIngestionPipeline(ctx, dArgs, version); err != nil {
 		log.Fatal(err)
 	}
 }
 
-// runIngestionPipeline is the unexported, testable core. It operates entirely
-// through ictx and never reads package-level state except for the project-wide
-// datasetUtils.TestFlags/TestArgs hooks.
-func runIngestionPipeline(ictx IngestContext, args []string, version string) error {
-	tooLargeDatasets := 0
-	emptyDatasets := 0
-	originalMap := make(map[string]string)
-
+func runIngestionPipeline(ictx IngestContext, dArgs []DatasetArgs, version string) error {
 	if datasetUtils.TestFlags != nil {
 		datasetUtils.TestFlags(map[string]interface{}{
 			"ingest":              ictx.Cfg.IngestFlag,
@@ -502,13 +606,10 @@ func runIngestionPipeline(ictx IngestContext, args []string, version string) err
 		return nil
 	}
 
-	dArgs, err := ParseAndValidateArgs(args)
-	if err != nil {
-		return err
-	}
-
 	if datasetUtils.TestArgs != nil {
-		datasetUtils.TestArgs([]interface{}{dArgs.MetadataFile, dArgs.DatasetFileListTxt, dArgs.FolderListingTxt})
+		for _, dArg := range dArgs {
+			datasetUtils.TestArgs([]interface{}{dArg.MetadataFile, dArg.DatasetFileListTxt, dArg.FolderListingTxt})
+		}
 		return nil
 	}
 
@@ -525,14 +626,79 @@ func runIngestionPipeline(ictx IngestContext, args []string, version string) err
 		return err
 	}
 
+	var allArchivable []string
+	var ownerGroup string
+	var skippedLinks, illegalFileNames uint
+	var emptyDatasets, tooLargeDatasets int
+
+	// datasetErrs accumulates failures without short-circuiting: datasets that
+	// succeeded must still be printed and (if requested) submitted for archival
+	// even when a sibling dataset in the same run failed.
+	var datasetErrs []error
+
+	for _, dArg := range dArgs {
+		res, err := runIngestionBeforeArchive(ictx, dArg, user, accessGroups)
+		if err != nil {
+			wrapped := fmt.Errorf("error ingesting dataset with metadata %q: %w", dArg.MetadataFile, err)
+			log.Println(wrapped)
+			datasetErrs = append(datasetErrs, wrapped)
+			continue
+		}
+		allArchivable = append(allArchivable, res.archivableDatasets...)
+		skippedLinks += res.skippedLinks
+		illegalFileNames += res.illegalFileNames
+		emptyDatasets += res.emptyDatasets
+		tooLargeDatasets += res.tooLargeDatasets
+		if ownerGroup == "" {
+			ownerGroup = res.ownerGroup
+		}
+	}
+	pipelineErr := errors.Join(datasetErrs...)
+
+	if !ictx.Cfg.IngestFlag {
+		color.Set(color.FgRed)
+		log.Printf("Note: you run in 'dry' mode to simply to check data consistency. Use the --ingest flag to really ingest datasets.")
+		color.Unset()
+	}
+
+	if skippedLinks > 0 {
+		color.Set(color.FgYellow)
+		log.Printf("Total number of link files skipped: %v\n", skippedLinks)
+		color.Unset()
+	}
+	if illegalFileNames > 0 {
+		color.Set(color.FgRed)
+		log.Printf("Number of files ignored because of illegal filenames: %v\n", illegalFileNames)
+		color.Unset()
+	}
+
+	if emptyDatasets > 0 || tooLargeDatasets > 0 {
+		pipelineErr = errors.Join(pipelineErr, fmt.Errorf("errors encountered with dataset layouts: %d empty, %d too large", emptyDatasets, tooLargeDatasets))
+	}
+
+	if err := submitAndPrintResults(ictx, user, ownerGroup, allArchivable); err != nil {
+		return errors.Join(pipelineErr, err)
+	}
+
+	return pipelineErr
+}
+
+// runIngestionBeforeArchive is the per-dataset core. It operates entirely
+// through ictx and the already-authenticated user/accessGroups shared across
+// the whole pipeline invocation, and never reads package-level state.
+func runIngestionBeforeArchive(ictx IngestContext, dArgs DatasetArgs, user map[string]string, accessGroups []string) (ingestionResult, error) {
+	tooLargeDatasets := 0
+	emptyDatasets := 0
+	originalMap := make(map[string]string)
+
 	metaDataMap, metadataSourceFolder, beamlineAccount, err := ictx.ReadAndCheckMetadata(ictx.Client, ictx.APIServer, dArgs.MetadataFile, user, accessGroups)
 	if err != nil {
-		return fmt.Errorf("error in CheckMetadata function: %w", err)
+		return ingestionResult{}, fmt.Errorf("error in CheckMetadata function: %w", err)
 	}
 
 	datasetPaths, err := ResolveDatasetPaths(metadataSourceFolder, dArgs.FolderListingTxt)
 	if err != nil {
-		return err
+		return ingestionResult{}, err
 	}
 
 	if err := GuardExistingSourceFolders(
@@ -540,7 +706,7 @@ func runIngestionPipeline(ictx IngestContext, args []string, version string) err
 		ictx.Cfg.AllowExistingSourceFolder, ictx.Cfg.AllowExistingSourceFolderChanged,
 		ictx.TestForExistingSourceFolder,
 	); err != nil {
-		return err
+		return ingestionResult{}, err
 	}
 
 	if ictx.Cfg.NocopyFlag {
@@ -565,7 +731,7 @@ func runIngestionPipeline(ictx IngestContext, args []string, version string) err
 
 	archivableDatasetListOwnerGroup, ok := metaDataMap["ownerGroup"].(string)
 	if !ok {
-		return errors.New("can't recover ownerGroup")
+		return ingestionResult{}, errors.New("can't recover ownerGroup")
 	}
 
 	for _, datasetSourceFolder := range datasetPaths {
@@ -578,7 +744,7 @@ func runIngestionPipeline(ictx IngestContext, args []string, version string) err
 
 		fileCtx, err := GatherFiles(datasetSourceFolder, dArgs.DatasetFileListTxt, &skipSymlinks, &skippedLinks, &illegalFileNames)
 		if err != nil {
-			return fmt.Errorf("can't gather filelist of %q: %w", datasetSourceFolder, err)
+			return ingestionResult{}, fmt.Errorf("can't gather filelist of %q: %w", datasetSourceFolder, err)
 		}
 
 		if fileCtx.TotalSize == 0 {
@@ -613,7 +779,7 @@ func runIngestionPipeline(ictx IngestContext, args []string, version string) err
 		if checkCentralAvailability {
 			requiresCopy, err = VerifyCentralAvailability(ictx.Cfg, ictx.RsyncServer, datasetSourceFolder, user, accessGroups, ictx.Scanner, ictx.CheckCentralAvailability)
 			if err != nil {
-				return err
+				return ingestionResult{}, err
 			}
 		}
 
@@ -626,7 +792,7 @@ func runIngestionPipeline(ictx IngestContext, args []string, version string) err
 
 		datasetId, err := RegisterDatasetWithCatalog(ictx.Client, ictx.APIServer, metaDataMap, fileCtx, user, ictx.Cfg, ictx.IngestDataset, ictx.AddAttachment)
 		if err != nil {
-			return err
+			return ingestionResult{}, err
 		}
 
 		if requiresCopy {
@@ -640,43 +806,14 @@ func runIngestionPipeline(ictx IngestContext, args []string, version string) err
 		ictx.ResetUpdatedMetaData(originalMap, metaDataMap)
 	}
 
-	if !ictx.Cfg.IngestFlag {
-		color.Set(color.FgRed)
-		log.Printf("Note: you run in 'dry' mode to simply to check data consistency. Use the --ingest flag to really ingest datasets.")
-		color.Unset()
-	}
-
-	if skippedLinks > 0 {
-		color.Set(color.FgYellow)
-		log.Printf("Total number of link files skipped: %v\n", skippedLinks)
-		color.Unset()
-	}
-	if illegalFileNames > 0 {
-		color.Set(color.FgRed)
-		log.Printf("Number of files ignored because of illegal filenames: %v\n", illegalFileNames)
-		color.Unset()
-	}
-
-	if emptyDatasets > 0 || tooLargeDatasets > 0 {
-		return fmt.Errorf("errors encountered with dataset layouts: %d empty, %d too large", emptyDatasets, tooLargeDatasets)
-	}
-
-	if ictx.Cfg.AutoarchiveFlag && ictx.Cfg.IngestFlag {
-		log.Printf("Submitting Archive Job for the ingested datasets.\n")
-		jobId, err := ictx.CreateArchivalJob(ictx.Client, ictx.APIServer, user, archivableDatasetListOwnerGroup, archivableDatasetList, &ictx.Cfg.Tapecopies, nil)
-		if err != nil {
-			color.Set(color.FgRed)
-			log.Printf("Could not create the archival job: %s\n", err.Error())
-			color.Unset()
-		} else {
-			log.Println("Submitted job:", jobId)
-		}
-	}
-
-	for _, id := range archivableDatasetList {
-		fmt.Println(id)
-	}
-	return nil
+	return ingestionResult{
+		archivableDatasets: archivableDatasetList,
+		ownerGroup:         archivableDatasetListOwnerGroup,
+		skippedLinks:       skippedLinks,
+		illegalFileNames:   illegalFileNames,
+		emptyDatasets:      emptyDatasets,
+		tooLargeDatasets:   tooLargeDatasets,
+	}, nil
 }
 
 func CreateLocalSymlinkCallbackForFileLister(skipSymlinks *string, skippedLinks *uint) func(symlinkPath string, sourceFolder string) (bool, error) {

--- a/orchestrator/ingest_test.go
+++ b/orchestrator/ingest_test.go
@@ -249,7 +249,11 @@ func TestRunIngestionPipelineMultipleSourceFoldersCreatesArchiveJob(t *testing.T
 		return "job-abc", nil
 	}
 
-	if err := runIngestionPipeline(ctx, []string{"meta.json", listPath}, "v1.0.0"); err != nil {
+	dArgsList, err := ParseAndValidateAllArgs([]string{"meta.json", listPath})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if err := runIngestionPipeline(ctx, dArgsList, "v1.0.0"); err != nil {
 		t.Fatalf("unexpected pipeline error: %v", err)
 	}
 
@@ -305,6 +309,143 @@ func TestParseAndValidateArgs(t *testing.T) {
 		}
 		if got.DatasetFileListTxt != "" {
 			t.Fatalf("dataset file list should be empty when folderlisting is provided")
+		}
+	})
+}
+
+func TestParseAndValidateSeparatorArg(t *testing.T) {
+	t.Run("meta with filelist", func(t *testing.T) {
+		got, err := ParseAndValidateSeparatorArg("meta.json@list.txt")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.MetadataFile != "meta.json" || got.DatasetFileListTxt != "list.txt" {
+			t.Fatalf("unexpected result: %#v", got)
+		}
+		expectedAbs, _ := filepath.Abs("list.txt")
+		if got.AbsFileListing != expectedAbs {
+			t.Fatalf("expected abs %s, got %s", expectedAbs, got.AbsFileListing)
+		}
+	})
+
+	t.Run("meta without filelist via separator", func(t *testing.T) {
+		got, err := ParseAndValidateSeparatorArg("meta.json@")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.MetadataFile != "meta.json" {
+			t.Fatalf("unexpected metadata file: %s", got.MetadataFile)
+		}
+		if got.DatasetFileListTxt != "" || got.AbsFileListing != "" {
+			t.Fatalf("expected empty filelist fields, got: %#v", got)
+		}
+	})
+
+	t.Run("no @ falls back to single meta arg", func(t *testing.T) {
+		got, err := ParseAndValidateSeparatorArg("meta.json")
+		if err != nil {
+			t.Fatalf("unexpected error for bare meta arg: %v", err)
+		}
+		if got.MetadataFile != "meta.json" {
+			t.Fatalf("unexpected metadata file: %s", got.MetadataFile)
+		}
+		if got.DatasetFileListTxt != "" || got.AbsFileListing != "" {
+			t.Fatalf("expected empty filelist fields, got: %#v", got)
+		}
+	})
+
+	t.Run("empty metadata returns error", func(t *testing.T) {
+		_, err := ParseAndValidateSeparatorArg("@list.txt")
+		if err == nil {
+			t.Fatal("expected error for empty metadata file")
+		}
+	})
+}
+
+func TestParseAndValidateAllArgs(t *testing.T) {
+	t.Run("legacy single arg", func(t *testing.T) {
+		got, err := ParseAndValidateAllArgs([]string{"meta.json"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].MetadataFile != "meta.json" {
+			t.Fatalf("unexpected result: %#v", got)
+		}
+	})
+
+	t.Run("legacy two args with filelist", func(t *testing.T) {
+		got, err := ParseAndValidateAllArgs([]string{"meta.json", "list.txt"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].DatasetFileListTxt != "list.txt" {
+			t.Fatalf("unexpected result: %#v", got)
+		}
+	})
+
+	t.Run("legacy two args with folderlisting", func(t *testing.T) {
+		got, err := ParseAndValidateAllArgs([]string{"meta.json", "folderlisting.txt"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].FolderListingTxt != "folderlisting.txt" {
+			t.Fatalf("unexpected result: %#v", got)
+		}
+	})
+
+	t.Run("@ syntax single pair", func(t *testing.T) {
+		got, err := ParseAndValidateAllArgs([]string{"meta.json@list.txt"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].MetadataFile != "meta.json" || got[0].DatasetFileListTxt != "list.txt" {
+			t.Fatalf("unexpected result: %#v", got)
+		}
+	})
+
+	t.Run("@ syntax multiple pairs", func(t *testing.T) {
+		got, err := ParseAndValidateAllArgs([]string{"a.json@l1.txt", "b.json@l2.txt", "c.json"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("expected 3 results, got %d", len(got))
+		}
+		if got[0].MetadataFile != "a.json" || got[1].MetadataFile != "b.json" || got[2].MetadataFile != "c.json" {
+			t.Fatalf("unexpected metadata files: %v %v %v", got[0].MetadataFile, got[1].MetadataFile, got[2].MetadataFile)
+		}
+		if got[2].DatasetFileListTxt != "" || got[2].AbsFileListing != "" {
+			t.Fatalf("expected empty filelist for third pair: %#v", got[2])
+		}
+	})
+
+	t.Run("empty args returns error", func(t *testing.T) {
+		_, err := ParseAndValidateAllArgs([]string{})
+		if err == nil {
+			t.Fatal("expected error for empty args")
+		}
+	})
+
+	t.Run("@ syntax with bare meta arg yields two datasets", func(t *testing.T) {
+		got, err := ParseAndValidateAllArgs([]string{"a.json@l.txt", "b.json"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(got))
+		}
+		if got[0].MetadataFile != "a.json" || got[0].DatasetFileListTxt != "l.txt" {
+			t.Fatalf("unexpected first dataset: %#v", got[0])
+		}
+		if got[1].MetadataFile != "b.json" || got[1].DatasetFileListTxt != "" {
+			t.Fatalf("unexpected second dataset: %#v", got[1])
+		}
+	})
+
+	t.Run("invalid separator pair format returns error", func(t *testing.T) {
+		_, err := ParseAndValidateAllArgs([]string{"a.json@l.txt", "bad.csv@list.txt"})
+		if err == nil {
+			t.Fatal("expected error for invalid @ pair format (left side not .json)")
 		}
 	})
 }
@@ -625,8 +766,184 @@ func TestRunIngestionPipelineReturnsErrorWhenReadMetadataFails(t *testing.T) {
 		return nil, "", false, metaErr
 	}
 
-	err := runIngestionPipeline(ctx, []string{"meta.json"}, "v1.0.0")
+	dArgsList, _ := ParseAndValidateAllArgs([]string{"meta.json"})
+	err := runIngestionPipeline(ctx, dArgsList, "v1.0.0")
 	if !errors.Is(err, metaErr) {
 		t.Fatalf("expected metadata error to propagate, got: %v", err)
+	}
+}
+
+func TestRunIngestionPipelineKeepsSuccessesWhenOneDatasetFails(t *testing.T) {
+	prevFlags := datasetUtils.TestFlags
+	prevArgs := datasetUtils.TestArgs
+	defer func() {
+		datasetUtils.TestFlags = prevFlags
+		datasetUtils.TestArgs = prevArgs
+	}()
+	datasetUtils.TestFlags = nil
+	datasetUtils.TestArgs = nil
+
+	tmp := t.TempDir()
+	metaErr := errors.New("bad metadata for b")
+
+	ctx := noopCtx()
+	ctx.Cfg = IngestConfig{
+		IngestFlag:        true,
+		AutoarchiveFlag:   true,
+		NocopyFlag:        true,
+		NocopyFlagChanged: true,
+	}
+	ctx.ReadAndCheckMetadata = func(_ *http.Client, _, metaFile string, _ map[string]string, _ []string) (map[string]interface{}, string, bool, error) {
+		if filepath.Base(metaFile) == "b.json" {
+			return nil, "", false, metaErr
+		}
+		dir := filepath.Join(tmp, strings.TrimSuffix(filepath.Base(metaFile), ".json"))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, "", false, err
+		}
+		if err := os.WriteFile(filepath.Join(dir, "data.dat"), []byte("x"), 0o600); err != nil {
+			return nil, "", false, err
+		}
+		return map[string]interface{}{"type": "raw", "ownerGroup": "grp"}, dir, false, nil
+	}
+	ctx.IngestDataset = func(_ *http.Client, _ string, meta map[string]interface{}, _ []datasetIngestor.Datafile, _ map[string]string) (string, error) {
+		return "pid-" + filepath.Base(meta["sourceFolder"].(string)), nil
+	}
+	var gotDatasets []string
+	ctx.CreateArchivalJob = func(_ *http.Client, _ string, _ map[string]string, _ string, datasets []string, _ *int, _ *time.Time) (string, error) {
+		gotDatasets = append([]string{}, datasets...)
+		return "job-abc", nil
+	}
+
+	dArgsList, err := ParseAndValidateAllArgs([]string{"a.json", "b.json", "c.json"})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		err = runIngestionPipeline(ctx, dArgsList, "v1.0.0")
+	})
+
+	if !errors.Is(err, metaErr) {
+		t.Fatalf("expected the b.json failure to propagate, got: %v", err)
+	}
+	if !strings.Contains(out, "pid-a") || !strings.Contains(out, "pid-c") {
+		t.Fatalf("expected successful datasets a and c to still be printed, got: %q", out)
+	}
+	want := []string{"pid-a", "pid-c"}
+	sort.Strings(want)
+	sort.Strings(gotDatasets)
+	if strings.Join(gotDatasets, ",") != strings.Join(want, ",") {
+		t.Fatalf("expected archival job to still include the successful datasets, got=%v want=%v", gotDatasets, want)
+	}
+}
+
+func TestRunIngestionPipelineAuthenticatesOnceAcrossMultipleDatasetArgs(t *testing.T) {
+	prevFlags := datasetUtils.TestFlags
+	prevArgs := datasetUtils.TestArgs
+	defer func() {
+		datasetUtils.TestFlags = prevFlags
+		datasetUtils.TestArgs = prevArgs
+	}()
+	datasetUtils.TestFlags = nil
+	datasetUtils.TestArgs = nil
+
+	tmp := t.TempDir()
+	var authCalls int
+	var ingested []string
+
+	ctx := noopCtx()
+	ctx.Cfg = IngestConfig{
+		IngestFlag:        true,
+		NocopyFlag:        true,
+		NocopyFlagChanged: true,
+	}
+	ctx.Authenticate = func(_ cliutils.Authenticator, _ *http.Client, _, _, _ string, _ bool, _ ...func(...any)) (map[string]string, []string, error) {
+		authCalls++
+		return map[string]string{"accessToken": "test-token", "username": "alice"}, []string{"group-a"}, nil
+	}
+	ctx.ReadAndCheckMetadata = func(_ *http.Client, _, metaFile string, _ map[string]string, _ []string) (map[string]interface{}, string, bool, error) {
+		dir := filepath.Join(tmp, strings.TrimSuffix(filepath.Base(metaFile), ".json"))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, "", false, err
+		}
+		if err := os.WriteFile(filepath.Join(dir, "data.dat"), []byte("x"), 0o600); err != nil {
+			return nil, "", false, err
+		}
+		return map[string]interface{}{"type": "raw", "ownerGroup": "grp"}, dir, false, nil
+	}
+	ctx.IngestDataset = func(_ *http.Client, _ string, meta map[string]interface{}, _ []datasetIngestor.Datafile, _ map[string]string) (string, error) {
+		id := "pid-" + filepath.Base(meta["sourceFolder"].(string))
+		ingested = append(ingested, id)
+		return id, nil
+	}
+
+	dArgsList, err := ParseAndValidateAllArgs([]string{"a.json", "b.json", "c.json"})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if err := runIngestionPipeline(ctx, dArgsList, "v1.0.0"); err != nil {
+		t.Fatalf("unexpected pipeline error: %v", err)
+	}
+
+	if len(ingested) != 3 {
+		t.Fatalf("expected 3 ingested datasets, got %d: %v", len(ingested), ingested)
+	}
+	if authCalls != 1 {
+		t.Fatalf("expected exactly 1 shared Authenticate call across the dataset batch, got %d", authCalls)
+	}
+}
+
+func TestValidateArgumentFormat(t *testing.T) {
+	tests := []struct {
+		arg     string
+		wantErr bool
+	}{
+		{"", true},
+		{"   ", true},
+		{"meta.json", false},
+		{"list.txt", false},
+		{"meta.json@list.txt", false},
+		{"meta.json@", true},
+		{"@list.txt", true},
+		{"notvalid", true},
+		{"/some/path/", true},
+		{"meta.json@bad.csv", true},
+		{"bad.csv@list.txt", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.arg, func(t *testing.T) {
+			err := ValidateArgumentFormat(tc.arg)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.arg)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.arg, err)
+			}
+		})
+	}
+}
+
+func TestIsLegacyMode(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"single arg", []string{"meta.json"}, false},
+		{"two args json+txt", []string{"meta.json", "list.txt"}, true},
+		{"two args json+folderlisting", []string{"meta.json", "folderlisting.txt"}, true},
+		{"two args json+json", []string{"meta.json", "other.json"}, false},
+		{"three args", []string{"a.json", "b.json", "c.json"}, false},
+		{"@ in first arg", []string{"meta.json@list.txt", "other.txt"}, false},
+		{"@ in second arg", []string{"meta.json", "list@extra.txt"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isLegacyMode(tc.args)
+			if got != tc.want {
+				t.Fatalf("isLegacyMode(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR adds the ability to ingest multiple datasets in a single command, instead of having to run datasetIngestor once per dataset.

Old behavior still works exactly as before. If you call the command the same way you always have — one metadata file, optionally with one filelist — nothing changes. That old usage is automatically recognized and handled through the very same code path as before.

New behavior: you can now list several metadata files (each optionally paired with its own filelist using @, e.g. metadata1.json@filelist1.txt metadata2.json@filelist2.txt), and they'll all be ingested in one run.

A few things worth knowing about how the batch is handled:

1. Counting problems across the batch: if some datasets in the batch are empty or too large to ingest, those counts are now totaled up across the whole batch and reported once at the end, rather than dataset-by-dataset.
2. Stops on the first failure: if any dataset in the list fails for a real error (not just "too large"/"empty", but something like a metadata or network error), the whole run stops right there — datasets later in the list won't be attempted.
3. One archive job instead of many: previously, auto-archiving submitted a separate archive request for every dataset folder. Now, a single archive job is submitted at the end covering every archivable dataset from the whole batch, instead of one per dataset.
