### PR TITLE
feat: add remotefilescan flag for remote archives

### DIFF
--- a/cmd/cliutils/commonTransfer.go
+++ b/cmd/cliutils/commonTransfer.go
@@ -12,6 +12,7 @@ type SshParams struct {
 	User            map[string]string
 	RsyncServer     string
 	AbsFilelistPath string
+	MarkFilesReady  bool
 }
 
 type GlobusParams struct {

--- a/cmd/cliutils/sshTransfer.go
+++ b/cmd/cliutils/sshTransfer.go
@@ -24,7 +24,9 @@ func SshTransfer(params TransferParams) (archivable bool, err error) {
 	if err == nil {
 		// mark dataset ready for archival
 		archivable = true
-		err = datasetIngestor.MarkFilesReady(client, apiServer, datasetId, user)
+		if params.MarkFilesReady {
+			err = datasetIngestor.MarkFilesReady(client, apiServer, datasetId, user)
+		}
 	}
 	log.Println("Syncing files - DONE")
 

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -61,7 +61,9 @@ func init() {
 	datasetIngestorCmd.Flags().String("addattachment", "", "Filename of image to attach (single dataset case only)")
 	datasetIngestorCmd.Flags().String("addcaption", "", "Optional caption to be stored with attachment (single dataset case only)")
 	datasetIngestorCmd.Flags().String("globus-cfg", "", "Override globus transfer config file location [default: globus.yaml next to executable]")
+	datasetIngestorCmd.Flags().Bool("remotefilescan", false, "Enable remote file scan instead of local file scan (only for central case, i.e. --nocopy).")
 
 	datasetIngestorCmd.MarkFlagsMutuallyExclusive("testenv", "devenv", "localenv", "tunnelenv")
 	datasetIngestorCmd.MarkFlagsMutuallyExclusive("nocopy", "copy")
+	datasetIngestorCmd.MarkFlagsMutuallyExclusive("remotefilescan", "copy")
 }

--- a/datasetIngestor/ingestDataset.go
+++ b/datasetIngestor/ingestDataset.go
@@ -69,7 +69,7 @@ The ID of the created dataset.
 */
 func IngestDataset(client *http.Client, APIServer string, metaDataMap map[string]interface{},
 	fullFileArray []Datafile, user map[string]string) (datasetId string, err error) {
-	datasetId, err = createDataset(client, APIServer, metaDataMap, user)
+	datasetId, err = CreateDataset(client, APIServer, metaDataMap, user)
 	if err != nil {
 		return datasetId, err
 	}
@@ -78,7 +78,7 @@ func IngestDataset(client *http.Client, APIServer string, metaDataMap map[string
 	return datasetId, err
 }
 
-func createDataset(client *http.Client, APIServer string, metaDataMap map[string]interface{}, user map[string]string) (string, error) {
+func CreateDataset(client *http.Client, APIServer string, metaDataMap map[string]interface{}, user map[string]string) (string, error) {
 	cmm, _ := json.Marshal(metaDataMap)
 	datasetId := ""
 

--- a/orchestrator/ingest.go
+++ b/orchestrator/ingest.go
@@ -56,6 +56,7 @@ type IngestConfig struct {
 	ShowVersion                      bool
 	GlobusCfgFlag                    string
 	GlobusCfgChanged                 bool
+	RemoteFileScan                   bool
 }
 
 type DatasetArgs struct {
@@ -139,6 +140,7 @@ func ParseConfig(cmd *cobra.Command) IngestConfig {
 		ShowVersion:                      cliutils.GetCobraBoolFlag(cmd, "version"),
 		GlobusCfgFlag:                    cliutils.GetCobraStringFlag(cmd, "globus-cfg"),
 		GlobusCfgChanged:                 cmd.Flags().Lookup("globus-cfg").Changed,
+		RemoteFileScan:                   cliutils.GetCobraBoolFlag(cmd, "remotefilescan"),
 	}
 }
 
@@ -472,6 +474,7 @@ func ExecuteFileTransfer(
 	globusClient globus.GlobusClient,
 	gConfig cliutils.GlobusConfig,
 	transferTypeFlag string,
+	markFilesReady bool,
 ) bool {
 	filePathList := make([]string, 0, len(fileCtx.FullFileArray))
 	isSymlinkList := make([]bool, 0, len(fileCtx.FullFileArray))
@@ -488,6 +491,7 @@ func ExecuteFileTransfer(
 			ApiServer:       apiServer,
 			RsyncServer:     rsyncServer,
 			AbsFilelistPath: absFileListing,
+			MarkFilesReady:  markFilesReady,
 		},
 		GlobusParams: cliutils.GlobusParams{
 			GlobusClient:   globusClient,
@@ -551,6 +555,13 @@ func RunIngestionPipeline(cmd *cobra.Command, args []string, version string) {
 		log.Fatal(err)
 	}
 
+	if cfg.RemoteFileScan {
+		cfg.NocopyFlag = true
+		cfg.NocopyFlagChanged = true
+	}
+
+	ingestFn := selectIngestFunction(cfg)
+
 	ctx := IngestContext{
 		Cfg:           cfg,
 		Client:        client,
@@ -569,7 +580,7 @@ func RunIngestionPipeline(cmd *cobra.Command, args []string, version string) {
 		CheckCentralAvailability:    datasetIngestor.CheckDataCentrallyAvailableSsh,
 		UpdateMetaData:              datasetIngestor.UpdateMetaData,
 		ResetUpdatedMetaData:        datasetIngestor.ResetUpdatedMetaData,
-		IngestDataset:               datasetIngestor.IngestDataset,
+		IngestDataset:               ingestFn,
 		AddAttachment:               datasetIngestor.AddAttachment,
 		CreateArchivalJob:           datasetUtils.CreateArchivalJob,
 	}
@@ -582,6 +593,16 @@ func RunIngestionPipeline(cmd *cobra.Command, args []string, version string) {
 	if err := runIngestionPipeline(ctx, dArgs, version); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func selectIngestFunction(cfg IngestConfig) func(client *http.Client, APIServer string, metaDataMap map[string]interface{}, fullFileArray []datasetIngestor.Datafile, user map[string]string) (string, error) {
+	ingestFn := datasetIngestor.IngestDataset
+	if cfg.RemoteFileScan {
+		ingestFn = func(client *http.Client, APIServer string, metaDataMap map[string]interface{}, fullFileArray []datasetIngestor.Datafile, user map[string]string) (string, error) {
+			return datasetIngestor.CreateDataset(client, APIServer, metaDataMap, user)
+		}
+	}
+	return ingestFn
 }
 
 func runIngestionPipeline(ictx IngestContext, dArgs []DatasetArgs, version string) error {
@@ -606,6 +627,7 @@ func runIngestionPipeline(ictx IngestContext, dArgs []DatasetArgs, version strin
 			"addattachment":       ictx.Cfg.AddAttachment,
 			"addcaption":          ictx.Cfg.AddCaption,
 			"version":             ictx.Cfg.ShowVersion,
+			"remotefilescan":      ictx.Cfg.RemoteFileScan,
 		})
 		return nil
 	}
@@ -796,37 +818,41 @@ func runIngestionBeforeArchive(ictx IngestContext, dArgs DatasetArgs, user map[s
 		log.Printf("===== Ingesting: \"%s\" =====\n", datasetSourceFolder)
 		metaDataMap["sourceFolder"] = datasetSourceFolder
 
-		fileCtx, err := GatherFiles(datasetSourceFolder, dArgs.DatasetFileListTxt, &skipSymlinks, &skippedLinks, &illegalFileNames, ictx.Cfg.NoninteractiveFlag)
-		if err != nil {
-			return ingestionResult{}, fmt.Errorf("can't gather filelist of %q: %w", datasetSourceFolder, err)
-		}
+		var err error
+		var fileCtx FileContext
+		if !ictx.Cfg.RemoteFileScan {
+			fileCtx, err = GatherFiles(datasetSourceFolder, dArgs.DatasetFileListTxt, &skipSymlinks, &skippedLinks, &illegalFileNames, ictx.Cfg.NoninteractiveFlag)
+			if err != nil {
+				return ingestionResult{}, fmt.Errorf("can't gather filelist of %q: %w", datasetSourceFolder, err)
+			}
 
-		if fileCtx.TotalSize == 0 {
-			emptyDatasets++
-			color.Set(color.FgRed)
-			log.Printf("\"%s\" dataset cannot be ingested - contains no files\n", datasetSourceFolder)
-			color.Unset()
-			continue
-		}
-		if fileCtx.NumFiles > cliutils.TOTAL_MAXFILES {
-			tooLargeDatasets++
-			color.Set(color.FgRed)
-			log.Printf("\"%s\" dataset cannot be ingested - too many files: has %d, max. %d\n", datasetSourceFolder, fileCtx.NumFiles, cliutils.TOTAL_MAXFILES)
-			color.Unset()
-			continue
+			if fileCtx.TotalSize == 0 {
+				emptyDatasets++
+				color.Set(color.FgRed)
+				log.Printf("\"%s\" dataset cannot be ingested - contains no files\n", datasetSourceFolder)
+				color.Unset()
+				continue
+			}
+			if fileCtx.NumFiles > cliutils.TOTAL_MAXFILES {
+				tooLargeDatasets++
+				color.Set(color.FgRed)
+				log.Printf("\"%s\" dataset cannot be ingested - too many files: has %d, max. %d\n", datasetSourceFolder, fileCtx.NumFiles, cliutils.TOTAL_MAXFILES)
+				color.Unset()
+				continue
+			}
+
+			ictx.UpdateMetaData(ictx.Client, ictx.APIServer, user, originalMap, metaDataMap, fileCtx.StartTime, fileCtx.EndTime, fileCtx.Owner, ictx.Cfg.Tapecopies)
+			if pretty, err := json.MarshalIndent(metaDataMap, "", "    "); err != nil {
+				log.Printf("Warning: could not marshal metadata for display: %v\n", err)
+			} else {
+				log.Printf("Updated metadata object:\n%s\n", pretty)
+			}
 		}
 
 		if ictx.Cfg.Tapecopies == 2 {
 			color.Set(color.FgYellow)
 			log.Println("Note: this dataset, if archived, will be copied to two tape copies")
 			color.Unset()
-		}
-
-		ictx.UpdateMetaData(ictx.Client, ictx.APIServer, user, originalMap, metaDataMap, fileCtx.StartTime, fileCtx.EndTime, fileCtx.Owner, ictx.Cfg.Tapecopies)
-		if pretty, err := json.MarshalIndent(metaDataMap, "", "    "); err != nil {
-			log.Printf("Warning: could not marshal metadata for display: %v\n", err)
-		} else {
-			log.Printf("Updated metadata object:\n%s\n", pretty)
 		}
 
 		requiresCopy := ictx.Cfg.CopyFlag
@@ -843,14 +869,18 @@ func runIngestionBeforeArchive(ictx IngestContext, dArgs DatasetArgs, user map[s
 		}
 
 		archivable := InitializeLifecycleFields(metaDataMap, requiresCopy)
-
+		if ictx.Cfg.RemoteFileScan {
+			if lifecycle, ok := metaDataMap["datasetlifecycle"].(map[string]interface{}); ok {
+				lifecycle["archiveStatusMessage"] = "origDatablocksNotYetAvailable"
+			}
+		}
 		datasetId, err := RegisterDatasetWithCatalog(ictx.Client, ictx.APIServer, metaDataMap, fileCtx, user, ictx.Cfg, ictx.IngestDataset, ictx.AddAttachment)
 		if err != nil {
 			return ingestionResult{}, err
 		}
 
 		if requiresCopy {
-			archivable = ExecuteFileTransfer(ictx.Client, ictx.APIServer, ictx.RsyncServer, datasetId, datasetSourceFolder, dArgs.AbsFileListing, user, fileCtx, ictx.TransferFiles, ictx.GlobusClient, ictx.GConfig, ictx.Cfg.TransferTypeFlag)
+			archivable = ExecuteFileTransfer(ictx.Client, ictx.APIServer, ictx.RsyncServer, datasetId, datasetSourceFolder, dArgs.AbsFileListing, user, fileCtx, ictx.TransferFiles, ictx.GlobusClient, ictx.GConfig, ictx.Cfg.TransferTypeFlag, !ictx.Cfg.RemoteFileScan)
 		}
 
 		if archivable {

--- a/orchestrator/ingest_test.go
+++ b/orchestrator/ingest_test.go
@@ -79,6 +79,7 @@ func makeIngestPipelineTestCmd() *cobra.Command {
 	cmd.Flags().String("addcaption", "", "")
 	cmd.Flags().Bool("version", false, "")
 	cmd.Flags().String("globus-cfg", "", "")
+	cmd.Flags().Bool("remotefilescan", false, "")
 	return cmd
 }
 
@@ -592,6 +593,7 @@ func TestExecuteFileTransferBuildsParams(t *testing.T) {
 		globus.GlobusClient{},
 		cliutils.GlobusConfig{},
 		"ssh",
+		true,
 	)
 
 	if !called {
@@ -619,6 +621,7 @@ func TestExecuteFileTransferReturnsFalseOnError(t *testing.T) {
 		globus.GlobusClient{},
 		cliutils.GlobusConfig{},
 		"ssh",
+		true,
 	)
 
 	if archivable {
@@ -1206,5 +1209,94 @@ func TestIsLegacyMode(t *testing.T) {
 				t.Fatalf("isLegacyMode(%v) = %v, want %v", tc.args, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRunIngestionPipelineRemoteFileScanSetsArchiveStatus verifies that with
+// --remotefilescan the orchestrator:
+//   - skips GatherFiles (sourceFolder is a non-existent remote path; if GatherFiles
+//     ran it would Chdir there and fail, causing the pipeline to error)
+//   - sets archiveStatusMessage to "origDatablocksNotYetAvailable"
+//   - registers the dataset as archivable (prints the dataset ID)
+func TestRunIngestionPipelineRemoteFileScanSetsArchiveStatus(t *testing.T) {
+	prevFlags := datasetUtils.TestFlags
+	prevArgs := datasetUtils.TestArgs
+	defer func() {
+		datasetUtils.TestFlags = prevFlags
+		datasetUtils.TestArgs = prevArgs
+	}()
+	datasetUtils.TestFlags = nil
+	datasetUtils.TestArgs = nil
+
+	var gotArchiveStatus string
+
+	ctx := noopCtx()
+	ctx.Cfg = IngestConfig{
+		IngestFlag:        true,
+		RemoteFileScan:    true,
+		NocopyFlag:        true,
+		NocopyFlagChanged: true,
+		Tapecopies:        1,
+	}
+	// Return a remote path that does not exist locally — GatherFiles would fail
+	// if called, so a successful pipeline proves it was skipped.
+	ctx.ReadAndCheckMetadata = func(*http.Client, string, string, map[string]string, []string) (map[string]interface{}, string, bool, error) {
+		return map[string]interface{}{"type": "raw", "ownerGroup": "grp"}, "/nonexistent/remote/source", false, nil
+	}
+	ctx.IngestDataset = func(_ *http.Client, _ string, meta map[string]interface{}, _ []datasetIngestor.Datafile, _ map[string]string) (string, error) {
+		if lc, ok := meta["datasetlifecycle"].(map[string]interface{}); ok {
+			gotArchiveStatus, _ = lc["archiveStatusMessage"].(string)
+		}
+		return "pid-remote", nil
+	}
+
+	out := captureStdout(t, func() {
+		dArgsList, err := ParseAndValidateAllArgs([]string{"meta.json"})
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if err := runIngestionPipeline(ctx, dArgsList, "v1.0.0"); err != nil {
+			t.Fatalf("pipeline error: %v", err)
+		}
+	})
+
+	if gotArchiveStatus != "origDatablocksNotYetAvailable" {
+		t.Fatalf("expected archiveStatusMessage %q, got %q", "origDatablocksNotYetAvailable", gotArchiveStatus)
+	}
+	if !strings.Contains(out, "pid-remote") {
+		t.Fatalf("expected dataset id in output, got: %q", out)
+	}
+}
+
+// TestExecuteFileTransferMarkFilesReadyPassedThrough verifies that the
+// markFilesReady flag is forwarded into SshParams.
+func TestExecuteFileTransferMarkFilesReadyPassedThrough(t *testing.T) {
+	for _, wantMark := range []bool{true, false} {
+		var gotMark bool
+		ExecuteFileTransfer(
+			&http.Client{}, "https://api", "rsync", "pid-1", "/src", "/list",
+			map[string]string{"username": "alice"},
+			FileContext{FullFileArray: []datasetIngestor.Datafile{{Path: "f"}}},
+			func(p cliutils.TransferParams) (bool, error) {
+				gotMark = p.SshParams.MarkFilesReady
+				return false, nil
+			},
+			globus.GlobusClient{}, cliutils.GlobusConfig{}, "ssh",
+			wantMark,
+		)
+		if gotMark != wantMark {
+			t.Fatalf("MarkFilesReady: got %v, want %v", gotMark, wantMark)
+		}
+	}
+}
+
+// TestSelectIngestFunction verifies that selectIngestFunction returns non-nil
+// for both modes (sanity check; real behavior tested via full-pipeline tests).
+func TestSelectIngestFunction(t *testing.T) {
+	if fn := selectIngestFunction(IngestConfig{RemoteFileScan: false}); fn == nil {
+		t.Fatal("expected non-nil function for RemoteFileScan=false")
+	}
+	if fn := selectIngestFunction(IngestConfig{RemoteFileScan: true}); fn == nil {
+		t.Fatal("expected non-nil function for RemoteFileScan=true")
 	}
 }


### PR DESCRIPTION
This branch builds on parallel_ds (parallel dataset ingestion) by adding a new --remotefilescan flag that supports ingesting datasets whose source files live on a remote/central system rather than the machine running the CLI.

* Adds a --remotefilescan flag (mutually exclusive with --copy) that, when set, skips the local GatherFiles file-system scan entirely — no local Chdir/stat calls against the source folder, since it doesn't exist locally.
* Automatically forces --nocopy behavior when --remotefilescan is set, since there's nothing to copy from a path the CLI can't see.
* Introduces selectIngestFunction, which swaps in a lighter-weight CreateDataset-only ingest path (renamed from the former unexported createDataset) instead of the full IngestDataset flow, since file-derived metadata/datablocks aren't available yet.
* Sets archiveStatusMessage: "origDatablocksNotYetAvailable" on the dataset lifecycle so downstream archival tooling knows the datablocks will be registered later by the remote/central process.
* Adds a MarkFilesReady flag to SshParams/ExecuteFileTransfer, allowing callers to opt out of marking files ready for archival during the SSH transfer step (now false in the remote-scan path, true otherwise).
