### PR TITLE
fix(checkMetadata): avoid unchecked type assertion of `ownerGroup`

### DIFF
--- a/datasetIngestor/checkMetadata.go
+++ b/datasetIngestor/checkMetadata.go
@@ -131,13 +131,13 @@ func CheckUserAndOwnerGroup(user map[string]string, accessGroups []string, metaD
 	}
 
 	// Check if the metadata contains the "ownerGroup" key.
-	ownerGroup, ok := metaDataMap["ownerGroup"]
+	ownerGroup, ok := metaDataMap["ownerGroup"].(string)
 	if !ok {
 		// NOTE: so if there's no ownergroup, we can pass this check?
-		return false, fmt.Errorf("no OwnerGroup attribute present in metadata")
+		return false, fmt.Errorf("attribute 'ownerGroup' is missing or invalid (expected string) in metadata")
 	}
 	// Iterate over accessGroups to validate the owner group.
-	if slices.Contains(accessGroups, ownerGroup.(string)) {
+	if slices.Contains(accessGroups, ownerGroup) {
 		return false, nil
 	}
 

--- a/datasetIngestor/checkMetadata_test.go
+++ b/datasetIngestor/checkMetadata_test.go
@@ -234,6 +234,64 @@ func TestCheckMetadata_ValidFalse(t *testing.T) {
 	}
 }
 
+func TestCheckUserAndOwnerGroup(t *testing.T) {
+	tests := []struct {
+		name             string
+		user             map[string]string
+		accessGroups     []string
+		metaDataMap      map[string]interface{}
+		wantBeamline     bool
+		wantErr          bool
+		wantErrSubstring string
+	}{
+		{
+			name:         "ownerGroup is a valid string present in accessGroups",
+			user:         map[string]string{"displayName": "someuser"},
+			accessGroups: []string{"group1", "group2"},
+			metaDataMap:  map[string]interface{}{"ownerGroup": "group1"},
+			wantBeamline: false,
+			wantErr:      false,
+		},
+		{
+			name:             "ownerGroup key missing from metadata",
+			user:             map[string]string{"displayName": "someuser"},
+			accessGroups:     []string{"group1"},
+			metaDataMap:      map[string]interface{}{},
+			wantErr:          true,
+			wantErrSubstring: "attribute 'ownerGroup' is missing or invalid",
+		},
+		{
+			name:             "ownerGroup present but not a string does not panic",
+			user:             map[string]string{"displayName": "someuser"},
+			accessGroups:     []string{"group1"},
+			metaDataMap:      map[string]interface{}{"ownerGroup": nil},
+			wantErr:          true,
+			wantErrSubstring: "attribute 'ownerGroup' is missing or invalid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			beamlineAccount, err := CheckUserAndOwnerGroup(tc.user, tc.accessGroups, tc.metaDataMap)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+					t.Errorf("expected error to contain %q, got %q", tc.wantErrSubstring, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, got %q", err.Error())
+			}
+
+			if beamlineAccount != tc.wantBeamline {
+				t.Errorf("expected beamlineAccount=%v, got %v", tc.wantBeamline, beamlineAccount)
+			}
+		})
+	}
+}
+
 func TestCheckMetadata_BeamlineAccount(t *testing.T) {
 	var metadatafile2 = "testdata/metadata-short.json"
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Prevents the following panic if `ownerGroup` is not a string
```
2026/07/06 13:08:52 Latest version: 3.1.0
2026/07/06 13:08:52 Your version of this program is up-to-date
2026/07/06 13:08:52 You are about to add a dataset to the === custom-production === data catalog environment...
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor.CheckUserAndOwnerGroup(0x3896f90fd10, {0x3896f92a0a0, 0x1, 0x12c?}, 0x3896f7b86c0)
    github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor/checkMetadata.go:140 +0x794
github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor.CheckMetadata(0x3896f74e9c0, {0x7ffd1b84b855, 0x1f}, 0x3896f7b86c0, 0x3896f90fd10, {0x3896f92a0a0, 0x1, 0x1})
    github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor/checkMetadata.go:44 +0x115
github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor.ReadAndCheckMetadata(0x3896f74e9c0, {0x7ffd1b84b855, 0x1f}, {0x7ffd1b84b9e2?, 0x9cac08?}, 0x3896f90fd10, {0x3896f92a0a0, 0x1, 0x1})
    github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor/checkMetadata.go:35 +0xa6
github.com/paulscherrerinstitute/scicat-cli/v3/cmd/commands.init.func4(0xddb4e0, {0x3896f7485a0, 0x2, 0x983785?})
    github.com/paulscherrerinstitute/scicat-cli/v3/cmd/commands/datasetIngestor.go:223 +0x1245
github.com/spf13/cobra.(*Command).execute(0xddb4e0, {0x3896f748510, 0x9, 0x9})
    github.com/spf13/cobra@v1.10.2/command.go:1019 +0xafb
github.com/spf13/cobra.(*Command).ExecuteC(0xddc340)
    github.com/spf13/cobra@v1.10.2/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
    github.com/spf13/cobra@v1.10.2/command.go:1071
github.com/paulscherrerinstitute/scicat-cli/v3/cmd/commands.Execute()
    github.com/paulscherrerinstitute/scicat-cli/v3/cmd/commands/root.go:28 +0x1a
main.main()
    github.com/paulscherrerinstitute/scicat-cli/v3/cmd/main.go:6 +0xf
```

The tests were generated by claude from the diff.