### PR TITLE
feat: add completeIngest command

### DIFF
--- a/cmd/commands/completeIngest.go
+++ b/cmd/commands/completeIngest.go
@@ -67,11 +67,10 @@ For further help see "` + cliutils.MANUAL + `"`,
 			return
 		}
 
-		if len(args) != 1 {
-			log.Println("invalid number of args")
-			return
+		pid, err := orchestrator.ExtractPidFromArgs(args)
+		if err != nil {
+			log.Fatal(err)
 		}
-		pid := args[0]
 
 		// === check for program version ===
 		datasetUtils.CheckForNewVersion(client, CMD, VERSION)

--- a/cmd/commands/completeIngest.go
+++ b/cmd/commands/completeIngest.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/paulscherrerinstitute/scicat-cli/v3/cmd/cliutils"
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+	"github.com/spf13/cobra"
+)
+
+var completeIngestCmd = &cobra.Command{
+	Use:   "completeIngest [options] datasetPid",
+	Short: "Complete the ingestion of a dataset by adding files to an existing dataset entry in the SciCat catalog",
+	Long: `Complete the ingestion of a dataset by adding files to an existing dataset entry in the SciCat catalog.
+This command is used to complete the ingestion of a dataset that was previously created without
+any files attached (NumberOfFiles == 0). It checks that the caller is allowed to perform the operation,
+that the dataset identified by pid exists, is empty and has a sourceFolder defined, then gathers the
+local file list from that sourceFolder and creates the corresponding origdatablocks. Symlinks are kept
+only when they point internally to the sourceFolder; filenames containing "*", "\" or three consecutive
+blanks are excluded from the dataset.
+
+For further help see "` + cliutils.MANUAL + `"`,
+	Args: rangeArgsWithVersionException(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		var client = &http.Client{
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: false}},
+			Timeout:   120 * time.Second}
+
+		const CMD = "completeIngest"
+
+		// pass parameters
+		envConfig := cliutils.InputEnvironmentConfig{
+			TestenvFlag:  cliutils.GetCobraBoolFlag(cmd, "testenv"),
+			DevenvFlag:   cliutils.GetCobraBoolFlag(cmd, "devenv"),
+			LocalenvFlag: cliutils.GetCobraBoolFlag(cmd, "localenv"),
+			ScicatUrl:    cliutils.GetCobraStringFlag(cmd, "scicat-url"),
+		}
+
+		// configure environment
+		APIServer := envConfig.ResolveAPIServer()
+
+		token := cliutils.GetCobraStringFlag(cmd, "token")
+		showVersion := cliutils.GetCobraBoolFlag(cmd, "version")
+
+		if datasetUtils.TestFlags != nil {
+			datasetUtils.TestFlags(map[string]interface{}{
+				"testenv":    envConfig.TestenvFlag,
+				"devenv":     envConfig.DevenvFlag,
+				"localenv":   envConfig.LocalenvFlag,
+				"scicat-url": envConfig.ScicatUrl,
+				"token":      token,
+			})
+			return
+		}
+
+		if showVersion {
+			fmt.Printf("%s\n", VERSION)
+			return
+		}
+
+		if len(args) != 1 {
+			log.Println("invalid number of args")
+			return
+		}
+		pid := args[0]
+
+		// === check for program version ===
+		datasetUtils.CheckForNewVersion(client, CMD, VERSION)
+
+		user, _, err := cliutils.Authenticate(cliutils.RealAuthenticator{}, client, APIServer, "", token, false)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if user["username"] != "archiveManager" {
+			log.Fatalf("You must be archiveManager to be allowed to delete datasets\n")
+		}
+
+		dataset, missing, err := datasetUtils.GetDatasetDetails(client, APIServer, user["accessToken"], []string{pid}, "")
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(missing) > 0 {
+			log.Fatalf("Dataset with PID %s not found\n", pid)
+		}
+		if len(dataset) != 1 {
+			log.Fatalf("Dataset with PID %s not found\n", pid)
+		}
+		if dataset[0].NumberOfFiles != 0 {
+			log.Fatalf("Dataset with PID %s already contains files\n", pid)
+		}
+
+		sourceFolder := dataset[0].SourceFolder
+		if sourceFolder == "" {
+			log.Fatalf("Dataset with PID %s has no sourceFolder defined\n", pid)
+		}
+
+		log.Printf("Dataset with PID %s has sourceFolder %s\n", pid, sourceFolder)
+
+		skipSymlinks := "dA"
+
+		var skippedLinks uint = 0
+		var illegalFileNames uint = 0
+		localSymlinkCallback := CreateLocalSymlinkCallbackForFileLister(&skipSymlinks, &skippedLinks)
+		localFilepathFilterCallback := CreateLocalFilenameFilterCallback(&illegalFileNames)
+
+		fullFileArray, _, _, _, numFiles, totalSize, err :=
+			datasetIngestor.GetLocalFileList(sourceFolder, "", localSymlinkCallback, localFilepathFilterCallback)
+		if err != nil {
+			log.Fatalf("Can't gather the filelist of \"%s\"", sourceFolder)
+		}
+
+		// filecount checks
+		if totalSize == 0 || numFiles == 0 {
+			color.Set(color.FgRed)
+			log.Fatalf("\"%s\" dataset cannot be ingested - contains no files\n", sourceFolder)
+			color.Unset()
+		}
+		if numFiles > cliutils.TOTAL_MAXFILES {
+			color.Set(color.FgRed)
+			log.Fatalf("\"%s\" dataset cannot be ingested - too many files: has %d, max. %d\n", sourceFolder, numFiles, cliutils.TOTAL_MAXFILES)
+			color.Unset()
+		}
+		// print file statistics
+		if skippedLinks > 0 {
+			color.Set(color.FgYellow)
+			log.Printf("Total number of link files skipped:%v\n", skippedLinks)
+			color.Unset()
+		}
+
+		if illegalFileNames > 0 {
+			color.Set(color.FgYellow)
+			log.Printf("Total number of illegal file names skipped:%v\n", illegalFileNames)
+			color.Unset()
+		}
+
+		err = datasetIngestor.CreateOrigDatablocks(client, APIServer, fullFileArray, pid, user)
+
+		if err != nil {
+			log.Fatalf("Error creating original data blocks for dataset %s: %v", pid, err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completeIngestCmd)
+
+	completeIngestCmd.Flags().Bool("nonInteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
+	completeIngestCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
+	completeIngestCmd.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")
+
+	completeIngestCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
+}

--- a/cmd/commands/completeIngest.go
+++ b/cmd/commands/completeIngest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/fatih/color"
@@ -86,11 +87,13 @@ For further help see "` + cliutils.MANUAL + `"`,
 			case *datasetIngestor.SkippedLinksWarning, *datasetIngestor.IllegalFileNamesWarning:
 				color.Set(color.FgYellow)
 				log.Print(err)
+				color.Unset()
 			default:
 				color.Set(color.FgRed)
-				log.Fatal(err)
+				log.Print(err)
+				color.Unset()
+				os.Exit(1)
 			}
-			color.Unset()
 		}
 
 	},
@@ -99,7 +102,6 @@ For further help see "` + cliutils.MANUAL + `"`,
 func init() {
 	rootCmd.AddCommand(completeIngestCmd)
 
-	completeIngestCmd.Flags().Bool("nonInteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
 	completeIngestCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
 	completeIngestCmd.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")
 

--- a/cmd/commands/completeIngest.go
+++ b/cmd/commands/completeIngest.go
@@ -11,6 +11,7 @@ import (
 	"github.com/paulscherrerinstitute/scicat-cli/v3/cmd/cliutils"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+	"github.com/paulscherrerinstitute/scicat-cli/v3/orchestrator"
 	"github.com/spf13/cobra"
 )
 
@@ -78,73 +79,20 @@ For further help see "` + cliutils.MANUAL + `"`,
 		if err != nil {
 			log.Fatal(err)
 		}
-		if user["username"] != "archiveManager" {
-			log.Fatalf("You must be archiveManager to be allowed to delete datasets\n")
-		}
 
-		dataset, missing, err := datasetUtils.GetDatasetDetails(client, APIServer, user["accessToken"], []string{pid}, "")
+		err = orchestrator.CompleteIngest(client, APIServer, user, pid)
 		if err != nil {
-			log.Fatal(err)
-		}
-		if len(missing) > 0 {
-			log.Fatalf("Dataset with PID %s not found\n", pid)
-		}
-		if len(dataset) != 1 {
-			log.Fatalf("Dataset with PID %s not found\n", pid)
-		}
-		if dataset[0].NumberOfFiles != 0 {
-			log.Fatalf("Dataset with PID %s already contains files\n", pid)
-		}
-
-		sourceFolder := dataset[0].SourceFolder
-		if sourceFolder == "" {
-			log.Fatalf("Dataset with PID %s has no sourceFolder defined\n", pid)
-		}
-
-		log.Printf("Dataset with PID %s has sourceFolder %s\n", pid, sourceFolder)
-
-		skipSymlinks := "dA"
-
-		var skippedLinks uint = 0
-		var illegalFileNames uint = 0
-		localSymlinkCallback := CreateLocalSymlinkCallbackForFileLister(&skipSymlinks, &skippedLinks)
-		localFilepathFilterCallback := CreateLocalFilenameFilterCallback(&illegalFileNames)
-
-		fullFileArray, _, _, _, numFiles, totalSize, err :=
-			datasetIngestor.GetLocalFileList(sourceFolder, "", localSymlinkCallback, localFilepathFilterCallback)
-		if err != nil {
-			log.Fatalf("Can't gather the filelist of \"%s\"", sourceFolder)
-		}
-
-		// filecount checks
-		if totalSize == 0 || numFiles == 0 {
-			color.Set(color.FgRed)
-			log.Fatalf("\"%s\" dataset cannot be ingested - contains no files\n", sourceFolder)
-			color.Unset()
-		}
-		if numFiles > cliutils.TOTAL_MAXFILES {
-			color.Set(color.FgRed)
-			log.Fatalf("\"%s\" dataset cannot be ingested - too many files: has %d, max. %d\n", sourceFolder, numFiles, cliutils.TOTAL_MAXFILES)
-			color.Unset()
-		}
-		// print file statistics
-		if skippedLinks > 0 {
-			color.Set(color.FgYellow)
-			log.Printf("Total number of link files skipped:%v\n", skippedLinks)
+			switch err.(type) {
+			case *datasetIngestor.SkippedLinksWarning, *datasetIngestor.IllegalFileNamesWarning:
+				color.Set(color.FgYellow)
+				log.Print(err)
+			default:
+				color.Set(color.FgRed)
+				log.Fatal(err)
+			}
 			color.Unset()
 		}
 
-		if illegalFileNames > 0 {
-			color.Set(color.FgYellow)
-			log.Printf("Total number of illegal file names skipped:%v\n", illegalFileNames)
-			color.Unset()
-		}
-
-		err = datasetIngestor.CreateOrigDatablocks(client, APIServer, fullFileArray, pid, user)
-
-		if err != nil {
-			log.Fatalf("Error creating original data blocks for dataset %s: %v", pid, err)
-		}
 	},
 }
 

--- a/cmd/commands/completeIngest.go
+++ b/cmd/commands/completeIngest.go
@@ -41,7 +41,6 @@ For further help see "` + cliutils.MANUAL + `"`,
 		envConfig := cliutils.InputEnvironmentConfig{
 			TestenvFlag:  cliutils.GetCobraBoolFlag(cmd, "testenv"),
 			DevenvFlag:   cliutils.GetCobraBoolFlag(cmd, "devenv"),
-			LocalenvFlag: cliutils.GetCobraBoolFlag(cmd, "localenv"),
 			ScicatUrl:    cliutils.GetCobraStringFlag(cmd, "scicat-url"),
 		}
 

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -282,8 +283,8 @@ For Windows you need instead to specify -user username:password on the command l
 
 		var skippedLinks uint = 0
 		var illegalFileNames uint = 0
-		localSymlinkCallback := CreateLocalSymlinkCallbackForFileLister(&skipSymlinks, &skippedLinks)
-		localFilepathFilterCallback := CreateLocalFilenameFilterCallback(&illegalFileNames)
+		localSymlinkCallback := datasetIngestor.CreateLocalSymlinkCallbackForFileLister(&skipSymlinks, &skippedLinks)
+		localFilepathFilterCallback := datasetIngestor.CreateLocalFilenameFilterCallback(&illegalFileNames)
 
 		// now everything is prepared, prepare to loop over all folders
 		var archivableDatasetList []string
@@ -309,29 +310,26 @@ For Windows you need instead to specify -user username:password on the command l
 			// === get filelist of dataset ===
 			log.Printf("Getting filelist for \"%s\"...\n", datasetSourceFolder)
 			fullFileArray, startTime, endTime, owner, numFiles, totalSize, err :=
-				datasetIngestor.GetLocalFileList(datasetSourceFolder, datasetFileListTxt, localSymlinkCallback, localFilepathFilterCallback)
+				datasetIngestor.GetValidatedLocalFileList(datasetSourceFolder, datasetFileListTxt, localSymlinkCallback, localFilepathFilterCallback)
 			if err != nil {
-				log.Fatalf("Can't gather the filelist of \"%s\"", datasetSourceFolder)
+				var emptyDatasetErr *datasetIngestor.EmptyDatasetError
+				var tooManyFilesErr *datasetIngestor.TooManyFilesError
+				switch {
+				case errors.As(err, &emptyDatasetErr):
+					emptyDatasets++
+				case errors.As(err, &tooManyFilesErr):
+					tooLargeDatasets++
+				default:
+					log.Fatalf("Can't gather the filelist of \"%s\": %v", datasetSourceFolder, err)
+				}
+				color.Set(color.FgRed)
+				log.Println(err)
+				color.Unset()
+				continue
 			}
 			log.Println("File list collected.")
 			//log.Printf("full fileListing: %v\n Start and end time: %s %s\n ", fullFileArray, startTime, endTime)
 			log.Printf("The dataset contains %v files with a total size of %v bytes.\n", numFiles, totalSize)
-
-			// filecount checks
-			if totalSize == 0 {
-				emptyDatasets++
-				color.Set(color.FgRed)
-				log.Printf("\"%s\" dataset cannot be ingested - contains no files\n", datasetSourceFolder)
-				color.Unset()
-				continue
-			}
-			if numFiles > cliutils.TOTAL_MAXFILES {
-				tooLargeDatasets++
-				color.Set(color.FgRed)
-				log.Printf("\"%s\" dataset cannot be ingested - too many files: has %d, max. %d\n", datasetSourceFolder, numFiles, cliutils.TOTAL_MAXFILES)
-				color.Unset()
-				continue
-			}
 
 			// NOTE: only tapecopies=1 or 2 does something if set.
 			if tapecopies == 2 {
@@ -485,11 +483,11 @@ For Windows you need instead to specify -user username:password on the command l
 		// print file statistics
 		if skippedLinks > 0 {
 			color.Set(color.FgYellow)
-			log.Printf("Total number of link files skipped:%v\n", skippedLinks)
+			log.Print(&datasetIngestor.SkippedLinksWarning{Count: skippedLinks})
 		}
 		if illegalFileNames > 0 {
 			color.Set(color.FgRed)
-			log.Printf("Number of files ignored because of illegal filenames:%v\n", illegalFileNames)
+			log.Print(&datasetIngestor.IllegalFileNamesWarning{Count: illegalFileNames})
 		}
 		color.Unset()
 
@@ -545,92 +543,4 @@ func init() {
 
 	datasetIngestorCmd.MarkFlagsMutuallyExclusive("testenv", "devenv", "localenv", "tunnelenv")
 	datasetIngestorCmd.MarkFlagsMutuallyExclusive("nocopy", "copy")
-}
-
-func CreateLocalSymlinkCallbackForFileLister(skipSymlinks *string, skippedLinks *uint) func(symlinkPath string, sourceFolder string) (bool, error) {
-	scanner := bufio.NewScanner(os.Stdin)
-	return func(symlinkPath string, sourceFolder string) (bool, error) {
-		keep := true
-		pointee, _ := os.Readlink(symlinkPath) // just pass the file name
-		if !filepath.IsAbs(pointee) {
-			symlinkAbs, err := filepath.Abs(filepath.Dir(symlinkPath))
-			if err != nil {
-				return false, err
-			}
-			pointeeAbs := filepath.Join(symlinkAbs, pointee)
-			pointee, err = filepath.EvalSymlinks(pointeeAbs)
-			if err != nil {
-				log.Printf("Could not follow symlink for file:%v %v", pointeeAbs, err)
-				keep = false
-				log.Printf("keep variable set to %v", keep)
-			}
-		}
-		if *skipSymlinks == "ka" || *skipSymlinks == "kA" {
-			keep = true
-		} else if *skipSymlinks == "sa" || *skipSymlinks == "sA" {
-			keep = false
-		} else if *skipSymlinks == "da" || *skipSymlinks == "dA" {
-			keep = strings.HasPrefix(pointee, sourceFolder)
-		} else {
-			color.Set(color.FgYellow)
-			log.Printf("Warning: the file %s is a link pointing to %v.", symlinkPath, pointee)
-			color.Unset()
-			log.Printf(`
-	Please test if this link is meaningful and not pointing
-	outside the sourceFolder %s. The default behaviour is to
-	keep only internal links within a source folder.
-	You can also specify that you want to apply the same answer to ALL
-	subsequent links within the current dataset, by appending an a (dA,ka,sa).
-	If you want to give the same answer even to all subsequent datasets
-	in this command then specify a capital 'A', e.g. (dA,kA,sA)
-	Do you want to keep the link in dataset or skip it (D(efault)/k(eep)/s(kip) ?`, sourceFolder)
-			scanner.Scan()
-			*skipSymlinks = scanner.Text()
-			if *skipSymlinks == "" {
-				*skipSymlinks = "d"
-			}
-			if *skipSymlinks == "d" || *skipSymlinks == "dA" {
-				keep = strings.HasPrefix(pointee, sourceFolder)
-			} else {
-				keep = (*skipSymlinks != "s" && *skipSymlinks != "sa" && *skipSymlinks != "sA")
-			}
-		}
-		if keep {
-			color.Set(color.FgGreen)
-			log.Printf("You chose to keep the link %v -> %v.\n\n", symlinkPath, pointee)
-		} else {
-			color.Set(color.FgRed)
-			*skippedLinks++
-			log.Printf("You chose to remove the link %v -> %v.\n\n", symlinkPath, pointee)
-		}
-		color.Unset()
-		return keep, nil
-	}
-}
-
-func CreateLocalFilenameFilterCallback(illegalFileNamesCounter *uint) func(filepath string) bool {
-	return func(filepath string) (keep bool) {
-		keep = true
-		// make sure that filenames do not contain characters like "\" or "*"
-		if strings.ContainsAny(filepath, "*\\") {
-			color.Set(color.FgRed)
-			log.Printf("Warning: the file %s contains illegal characters like *,\\ and will not be archived.", filepath)
-			color.Unset()
-			if illegalFileNamesCounter != nil {
-				*illegalFileNamesCounter++
-			}
-			keep = false
-		}
-		// and check for triple blanks, they are used to separate columns in messages
-		if keep && strings.Contains(filepath, "   ") {
-			color.Set(color.FgRed)
-			log.Printf("Warning: the file %s contains 3 consecutive blanks which is not allowed. The file not be archived.", filepath)
-			color.Unset()
-			if illegalFileNamesCounter != nil {
-				*illegalFileNamesCounter++
-			}
-			keep = false
-		}
-		return keep
-	}
 }

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -282,8 +282,8 @@ For Windows you need instead to specify -user username:password on the command l
 
 		var skippedLinks uint = 0
 		var illegalFileNames uint = 0
-		localSymlinkCallback := createLocalSymlinkCallbackForFileLister(&skipSymlinks, &skippedLinks)
-		localFilepathFilterCallback := createLocalFilenameFilterCallback(&illegalFileNames)
+		localSymlinkCallback := CreateLocalSymlinkCallbackForFileLister(&skipSymlinks, &skippedLinks)
+		localFilepathFilterCallback := CreateLocalFilenameFilterCallback(&illegalFileNames)
 
 		// now everything is prepared, prepare to loop over all folders
 		var archivableDatasetList []string
@@ -547,7 +547,7 @@ func init() {
 	datasetIngestorCmd.MarkFlagsMutuallyExclusive("nocopy", "copy")
 }
 
-func createLocalSymlinkCallbackForFileLister(skipSymlinks *string, skippedLinks *uint) func(symlinkPath string, sourceFolder string) (bool, error) {
+func CreateLocalSymlinkCallbackForFileLister(skipSymlinks *string, skippedLinks *uint) func(symlinkPath string, sourceFolder string) (bool, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	return func(symlinkPath string, sourceFolder string) (bool, error) {
 		keep := true
@@ -608,7 +608,7 @@ func createLocalSymlinkCallbackForFileLister(skipSymlinks *string, skippedLinks 
 	}
 }
 
-func createLocalFilenameFilterCallback(illegalFileNamesCounter *uint) func(filepath string) bool {
+func CreateLocalFilenameFilterCallback(illegalFileNamesCounter *uint) func(filepath string) bool {
 	return func(filepath string) (keep bool) {
 		keep = true
 		// make sure that filenames do not contain characters like "\" or "*"

--- a/datasetIngestor/getLocalFileList.go
+++ b/datasetIngestor/getLocalFileList.go
@@ -41,6 +41,47 @@ func readLines(path string) ([]string, error) {
 	return lines, scanner.Err()
 }
 
+// EmptyDatasetError indicates that a dataset's sourceFolder contains no files at all, so there is
+// nothing to ingest.
+type EmptyDatasetError struct {
+	SourceFolder string
+}
+
+func (e *EmptyDatasetError) Error() string {
+	return fmt.Sprintf("%q dataset cannot be ingested - contains no files", e.SourceFolder)
+}
+
+// TooManyFilesError indicates that a dataset's sourceFolder contains more files than the
+// archiving system can handle for a single dataset.
+type TooManyFilesError struct {
+	SourceFolder string
+	NumFiles     int64
+	MaxFiles     int
+}
+
+func (e *TooManyFilesError) Error() string {
+	return fmt.Sprintf("%q dataset cannot be ingested - too many files: has %d, max. %d", e.SourceFolder, e.NumFiles, e.MaxFiles)
+}
+
+// SkippedLinksWarning reports how many symlinks were skipped while gathering a local file list.
+type SkippedLinksWarning struct {
+	Count uint
+}
+
+func (w *SkippedLinksWarning) Error() string {
+	return fmt.Sprintf("Total number of link files skipped:%v", w.Count)
+}
+
+// IllegalFileNamesWarning reports how many files were excluded from a dataset because of an
+// illegal filename.
+type IllegalFileNamesWarning struct {
+	Count uint
+}
+
+func (w *IllegalFileNamesWarning) Error() string {
+	return fmt.Sprintf("Total number of illegal file names skipped:%v", w.Count)
+}
+
 /*
 GetLocalFileList scans a source folder and optionally a file listing, and returns a list of data files, the earliest and latest modification times, the owner, the number of files, and the total size of the files.
 
@@ -208,4 +249,32 @@ func handleSymlink(symlinkPath string, sourceFolder string) (bool, error) {
 	// keep symlink if it points to somewhere *within* the sourceFolder
 	keep = strings.HasPrefix(pointee, sourceFolder)
 	return keep, nil
+}
+
+/*
+GetValidatedLocalFileList gathers the local file list for sourceFolder exactly like
+GetLocalFileList, additionally validating that the resulting dataset is neither empty nor larger
+than TOTAL_MAXFILES. It returns an *EmptyDatasetError or *TooManyFilesError when one of those
+conditions is met, so callers share the same validation rules and error types.
+*/
+func GetValidatedLocalFileList(sourceFolder string, filelistingPath string,
+	symlinkCallback func(symlinkPath string, sourceFolder string) (bool, error),
+	filenameFilterCallback func(filepath string) bool,
+) (fullFileArray []Datafile, startTime time.Time, endTime time.Time, owner string, numFiles int64, totalSize int64, err error) {
+	fullFileArray, startTime, endTime, owner, numFiles, totalSize, err =
+		GetLocalFileList(sourceFolder, filelistingPath, symlinkCallback, filenameFilterCallback)
+	if err != nil {
+		return fullFileArray, startTime, endTime, owner, numFiles, totalSize,
+			fmt.Errorf("can't gather the filelist of %q: %w", sourceFolder, err)
+	}
+
+	if totalSize == 0 || numFiles == 0 {
+		return fullFileArray, startTime, endTime, owner, numFiles, totalSize, &EmptyDatasetError{SourceFolder: sourceFolder}
+	}
+	if numFiles > TOTAL_MAXFILES {
+		return fullFileArray, startTime, endTime, owner, numFiles, totalSize,
+			&TooManyFilesError{SourceFolder: sourceFolder, NumFiles: numFiles, MaxFiles: TOTAL_MAXFILES}
+	}
+
+	return fullFileArray, startTime, endTime, owner, numFiles, totalSize, nil
 }

--- a/datasetIngestor/getLocalFileList_test.go
+++ b/datasetIngestor/getLocalFileList_test.go
@@ -1,6 +1,7 @@
 package datasetIngestor
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -59,4 +60,87 @@ func TestAssembleFilelisting(t *testing.T) {
 	if totalSize != 4 {
 		t.Errorf("Expected totalSize to be 4, got %d", totalSize)
 	}
+}
+
+func TestEmptyDatasetErrorMessage(t *testing.T) {
+	err := &EmptyDatasetError{SourceFolder: "/some/folder"}
+	want := `"/some/folder" dataset cannot be ingested - contains no files`
+	if got := err.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTooManyFilesErrorMessage(t *testing.T) {
+	err := &TooManyFilesError{SourceFolder: "/some/folder", NumFiles: 5, MaxFiles: 3}
+	want := `"/some/folder" dataset cannot be ingested - too many files: has 5, max. 3`
+	if got := err.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSkippedLinksWarningMessage(t *testing.T) {
+	warning := &SkippedLinksWarning{Count: 2}
+	want := "Total number of link files skipped:2"
+	if got := warning.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestIllegalFileNamesWarningMessage(t *testing.T) {
+	warning := &IllegalFileNamesWarning{Count: 3}
+	want := "Total number of illegal file names skipped:3"
+	if got := warning.Error(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetValidatedLocalFileList(t *testing.T) {
+	t.Run("returns the file list when the dataset is not empty", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("Failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		filePath := filepath.Join(tempDir, "testfile")
+		if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %s", err)
+		}
+
+		fullFileArray, _, _, _, numFiles, totalSize, err := GetValidatedLocalFileList(tempDir, "", nil, nil)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if len(fullFileArray) != 1 || numFiles != 1 {
+			t.Errorf("expected 1 file, got %d entries and numFiles=%d", len(fullFileArray), numFiles)
+		}
+		if totalSize != 4 {
+			t.Errorf("expected totalSize 4, got %d", totalSize)
+		}
+	})
+
+	t.Run("returns an EmptyDatasetError when the sourceFolder contains no files", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("Failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		_, _, _, _, _, _, err = GetValidatedLocalFileList(tempDir, "", nil, nil)
+		var emptyDatasetErr *EmptyDatasetError
+		if !errors.As(err, &emptyDatasetErr) {
+			t.Fatalf("expected an *EmptyDatasetError, got: %v (%T)", err, err)
+		}
+	})
+
+	t.Run("wraps the underlying error when the sourceFolder does not exist", func(t *testing.T) {
+		_, _, _, _, _, _, err := GetValidatedLocalFileList("./does-not-exist", "", nil, nil)
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		var emptyDatasetErr *EmptyDatasetError
+		if errors.As(err, &emptyDatasetErr) {
+			t.Fatalf("expected a plain gathering error, not an *EmptyDatasetError: %v", err)
+		}
+	})
 }

--- a/datasetIngestor/ingestDataset.go
+++ b/datasetIngestor/ingestDataset.go
@@ -73,7 +73,7 @@ func IngestDataset(client *http.Client, APIServer string, metaDataMap map[string
 	if err != nil {
 		return datasetId, err
 	}
-	err = createOrigDatablocks(client, APIServer, fullFileArray, datasetId, user)
+	err = CreateOrigDatablocks(client, APIServer, fullFileArray, datasetId, user)
 
 	return datasetId, err
 }
@@ -148,7 +148,7 @@ If a request receives a response with a status code other than 200, the function
 
 The function logs a message for each created data block, including the start and end file, the total size, and the number of files in the block.
 */
-func createOrigDatablocks(client *http.Client, APIServer string, fullFileArray []Datafile, datasetId string, user map[string]string) error {
+func CreateOrigDatablocks(client *http.Client, APIServer string, fullFileArray []Datafile, datasetId string, user map[string]string) error {
 	totalFiles := len(fullFileArray)
 
 	if totalFiles > TOTAL_MAXFILES {

--- a/datasetIngestor/ingestDataset_test.go
+++ b/datasetIngestor/ingestDataset_test.go
@@ -201,7 +201,7 @@ func TestCreateOrigDatablocks(t *testing.T) {
 			}
 
 			// Call the function with test data
-			createOrigDatablocks(client, server.URL, tc.datafiles, "testDatasetId", user)
+			CreateOrigDatablocks(client, server.URL, tc.datafiles, "testDatasetId", user)
 
 			// Check if the correct number of requests were made
 			if numRequests != tc.expectedRequests {

--- a/datasetIngestor/localFileListCallbacks.go
+++ b/datasetIngestor/localFileListCallbacks.go
@@ -1,0 +1,119 @@
+package datasetIngestor
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+/*
+CreateLocalSymlinkCallbackForFileLister builds the symlinkCallback used by GetLocalFileList to
+decide, for every symbolic link found under a sourceFolder, whether it should be kept in the
+dataset or skipped.
+
+skipSymlinks holds the current policy and is mutated as the user answers interactive prompts:
+  - "ka"/"kA" always keep, "sa"/"sA" always skip, "da"/"dA" keep only links internal to the
+    sourceFolder (the default behaviour).
+  - any other value (e.g. the initial single-letter "k"/"s"/"d") triggers an interactive prompt
+    on stdin for that particular link; the answer given there may update skipSymlinks to one of
+    the "*a"/"*A" forms above to apply to subsequent links.
+
+skippedLinks is incremented every time a link is skipped, so callers can report a summary count.
+*/
+func CreateLocalSymlinkCallbackForFileLister(skipSymlinks *string, skippedLinks *uint) func(symlinkPath string, sourceFolder string) (bool, error) {
+	scanner := bufio.NewScanner(os.Stdin)
+	return func(symlinkPath string, sourceFolder string) (bool, error) {
+		keep := true
+		pointee, _ := os.Readlink(symlinkPath) // just pass the file name
+		if !filepath.IsAbs(pointee) {
+			symlinkAbs, err := filepath.Abs(filepath.Dir(symlinkPath))
+			if err != nil {
+				return false, err
+			}
+			pointeeAbs := filepath.Join(symlinkAbs, pointee)
+			pointee, err = filepath.EvalSymlinks(pointeeAbs)
+			if err != nil {
+				log.Printf("Could not follow symlink for file:%v %v", pointeeAbs, err)
+				keep = false
+				log.Printf("keep variable set to %v", keep)
+			}
+		}
+		if *skipSymlinks == "ka" || *skipSymlinks == "kA" {
+			keep = true
+		} else if *skipSymlinks == "sa" || *skipSymlinks == "sA" {
+			keep = false
+		} else if *skipSymlinks == "da" || *skipSymlinks == "dA" {
+			keep = strings.HasPrefix(pointee, sourceFolder)
+		} else {
+			color.Set(color.FgYellow)
+			log.Printf("Warning: the file %s is a link pointing to %v.", symlinkPath, pointee)
+			color.Unset()
+			log.Printf(`
+	Please test if this link is meaningful and not pointing
+	outside the sourceFolder %s. The default behaviour is to
+	keep only internal links within a source folder.
+	You can also specify that you want to apply the same answer to ALL
+	subsequent links within the current dataset, by appending an a (dA,ka,sa).
+	If you want to give the same answer even to all subsequent datasets
+	in this command then specify a capital 'A', e.g. (dA,kA,sA)
+	Do you want to keep the link in dataset or skip it (D(efault)/k(eep)/s(kip) ?`, sourceFolder)
+			scanner.Scan()
+			*skipSymlinks = scanner.Text()
+			if *skipSymlinks == "" {
+				*skipSymlinks = "d"
+			}
+			if *skipSymlinks == "d" || *skipSymlinks == "dA" {
+				keep = strings.HasPrefix(pointee, sourceFolder)
+			} else {
+				keep = (*skipSymlinks != "s" && *skipSymlinks != "sa" && *skipSymlinks != "sA")
+			}
+		}
+		if keep {
+			color.Set(color.FgGreen)
+			log.Printf("You chose to keep the link %v -> %v.\n\n", symlinkPath, pointee)
+		} else {
+			color.Set(color.FgRed)
+			*skippedLinks++
+			log.Printf("You chose to remove the link %v -> %v.\n\n", symlinkPath, pointee)
+		}
+		color.Unset()
+		return keep, nil
+	}
+}
+
+/*
+CreateLocalFilenameFilterCallback builds the filenameCheckCallback used by GetLocalFileList to
+reject file paths that can't be archived: names containing "*" or "\", or three consecutive
+blanks (used as a column separator in messages). illegalFileNamesCounter, if non-nil, is
+incremented for every rejected file so callers can report a summary count.
+*/
+func CreateLocalFilenameFilterCallback(illegalFileNamesCounter *uint) func(filepath string) bool {
+	return func(filepath string) (keep bool) {
+		keep = true
+		// make sure that filenames do not contain characters like "\" or "*"
+		if strings.ContainsAny(filepath, "*\\") {
+			color.Set(color.FgRed)
+			log.Printf("Warning: the file %s contains illegal characters like *,\\ and will not be archived.", filepath)
+			color.Unset()
+			if illegalFileNamesCounter != nil {
+				*illegalFileNamesCounter++
+			}
+			keep = false
+		}
+		// and check for triple blanks, they are used to separate columns in messages
+		if keep && strings.Contains(filepath, "   ") {
+			color.Set(color.FgRed)
+			log.Printf("Warning: the file %s contains 3 consecutive blanks which is not allowed. The file not be archived.", filepath)
+			color.Unset()
+			if illegalFileNamesCounter != nil {
+				*illegalFileNamesCounter++
+			}
+			keep = false
+		}
+		return keep
+	}
+}

--- a/datasetIngestor/localFileListCallbacks_test.go
+++ b/datasetIngestor/localFileListCallbacks_test.go
@@ -1,0 +1,114 @@
+package datasetIngestor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateLocalSymlinkCallbackForFileLister(t *testing.T) {
+	sourceDir, err := os.MkdirTemp("./", "source")
+	if err != nil {
+		t.Fatalf("failed to create source directory: %s", err)
+	}
+	defer os.RemoveAll(sourceDir)
+	sourceDirAbs, err := filepath.Abs(sourceDir)
+	if err != nil {
+		t.Fatalf("failed to resolve source directory: %s", err)
+	}
+
+	outsideDir, err := os.MkdirTemp("./", "outside")
+	if err != nil {
+		t.Fatalf("failed to create outside directory: %s", err)
+	}
+	defer os.RemoveAll(outsideDir)
+	outsideDirAbs, err := filepath.Abs(outsideDir)
+	if err != nil {
+		t.Fatalf("failed to resolve outside directory: %s", err)
+	}
+
+	internalTarget := filepath.Join(sourceDirAbs, "internal.txt")
+	if err := os.WriteFile(internalTarget, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create internal target file: %s", err)
+	}
+	internalLink := filepath.Join(sourceDirAbs, "internalLink.txt")
+	if err := os.Symlink(internalTarget, internalLink); err != nil {
+		t.Fatalf("failed to create internal symlink: %s", err)
+	}
+
+	externalTarget := filepath.Join(outsideDirAbs, "external.txt")
+	if err := os.WriteFile(externalTarget, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create external target file: %s", err)
+	}
+	externalLink := filepath.Join(sourceDirAbs, "externalLink.txt")
+	if err := os.Symlink(externalTarget, externalLink); err != nil {
+		t.Fatalf("failed to create external symlink: %s", err)
+	}
+
+	testCases := []struct {
+		name         string
+		policy       string
+		symlinkPath  string
+		expectedKeep bool
+	}{
+		{"kA always keeps internal links", "kA", internalLink, true},
+		{"kA always keeps external links", "kA", externalLink, true},
+		{"sA always skips internal links", "sA", internalLink, false},
+		{"sA always skips external links", "sA", externalLink, false},
+		{"dA keeps internal links", "dA", internalLink, true},
+		{"dA skips external links", "dA", externalLink, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := tc.policy
+			var skippedLinks uint
+			callback := CreateLocalSymlinkCallbackForFileLister(&policy, &skippedLinks)
+
+			keep, err := callback(tc.symlinkPath, sourceDirAbs)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if keep != tc.expectedKeep {
+				t.Errorf("expected keep=%v, got %v", tc.expectedKeep, keep)
+			}
+			if !keep && skippedLinks != 1 {
+				t.Errorf("expected skippedLinks to be incremented, got %d", skippedLinks)
+			}
+			if keep && skippedLinks != 0 {
+				t.Errorf("expected skippedLinks to stay at 0, got %d", skippedLinks)
+			}
+		})
+	}
+}
+
+func TestCreateLocalFilenameFilterCallback(t *testing.T) {
+	testCases := []struct {
+		name         string
+		filepath     string
+		expectedKeep bool
+	}{
+		{"plain filename is kept", "some/normal/file.txt", true},
+		{"asterisk is rejected", "some/file*.txt", false},
+		{"backslash is rejected", `some\file.txt`, false},
+		{"triple blank is rejected", "some/file   name.txt", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var illegalFileNames uint
+			callback := CreateLocalFilenameFilterCallback(&illegalFileNames)
+
+			keep := callback(tc.filepath)
+			if keep != tc.expectedKeep {
+				t.Errorf("expected keep=%v, got %v", tc.expectedKeep, keep)
+			}
+			if !keep && illegalFileNames != 1 {
+				t.Errorf("expected illegalFileNames to be incremented, got %d", illegalFileNames)
+			}
+			if keep && illegalFileNames != 0 {
+				t.Errorf("expected illegalFileNames to stay at 0, got %d", illegalFileNames)
+			}
+		})
+	}
+}

--- a/datasetUtils/getDatasetDetails.go
+++ b/datasetUtils/getDatasetDetails.go
@@ -53,7 +53,7 @@ func GetDatasetDetails(client *http.Client, APIServer string, accessToken string
 		if ownerGroup != "" {
 			filter += `,"ownerGroup":"` + ownerGroup + `"`
 		}
-		filter += `},"fields":{"pid":true,"sourceFolder":true,"size":true,"ownerGroup":true}}`
+		filter += `},"fields":{"pid":true,"sourceFolder":true,"size":true,"ownerGroup":true, "numberOfFiles":true}}`
 
 		v := url.Values{}
 		v.Set("filter", filter)

--- a/datasetUtils/getDatasetDetails_test.go
+++ b/datasetUtils/getDatasetDetails_test.go
@@ -148,7 +148,7 @@ func TestGetDatasetDetails_FilterString(t *testing.T) {
 	accessToken := "testToken"
 	datasetList := []string{"123"}
 	ownerGroup := "group1"
-	expectedFilter := `{"where":{"pid":{"inq":["` + strings.Join(datasetList, `","`) + `"]},"ownerGroup":"` + ownerGroup + `"},"fields":{"pid":true,"sourceFolder":true,"size":true,"ownerGroup":true}}`
+	expectedFilter := `{"where":{"pid":{"inq":["` + strings.Join(datasetList, `","`) + `"]},"ownerGroup":"` + ownerGroup + `"},"fields":{"pid":true,"sourceFolder":true,"size":true,"ownerGroup":true, "numberOfFiles":true}}`
 
 	// Create a mock server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/datasetUtils/patchDataset.go
+++ b/datasetUtils/patchDataset.go
@@ -1,0 +1,30 @@
+package datasetUtils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+func PatchDataset(client *http.Client, APIServer string, token string, datasetId string, meta map[string]interface{}) error {
+	cmm, _ := json.Marshal(meta)
+
+	myurl := APIServer + "/Datasets/" + url.QueryEscape(datasetId)
+	req, err := http.NewRequest("PATCH", myurl, bytes.NewBuffer(cmm))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
+		return fmt.Errorf("failed to update dataset %v %v", resp.StatusCode, meta)
+	}
+	return nil
+}

--- a/datasetUtils/patchDataset_test.go
+++ b/datasetUtils/patchDataset_test.go
@@ -1,0 +1,75 @@
+package datasetUtils
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPatchDataset(t *testing.T) {
+	t.Run("sends a PATCH request with the given metadata and succeeds on 200", func(t *testing.T) {
+		var gotBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if req.URL.String() != "/Datasets/testPid" {
+				t.Errorf("expected URL '/Datasets/testPid', got '%s'", req.URL.String())
+			}
+			if req.Method != http.MethodPatch {
+				t.Errorf("expected method PATCH, got '%s'", req.Method)
+			}
+			if req.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("expected header 'Content-Type: application/json', got '%s'", req.Header.Get("Content-Type"))
+			}
+			if req.Header.Get("Authorization") != "Bearer testToken" {
+				t.Errorf("expected header 'Authorization: Bearer testToken', got '%s'", req.Header.Get("Authorization"))
+			}
+
+			body, _ := io.ReadAll(req.Body)
+			if err := json.Unmarshal(body, &gotBody); err != nil {
+				t.Fatalf("failed to unmarshal request body: %v", err)
+			}
+
+			rw.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		meta := map[string]interface{}{"creationTime": "2024-01-01T00:00:00Z"}
+		err := PatchDataset(server.Client(), server.URL, "testToken", "testPid", meta)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if gotBody["creationTime"] != "2024-01-01T00:00:00Z" {
+			t.Errorf("expected creationTime '2024-01-01T00:00:00Z' in request body, got: %v", gotBody)
+		}
+	})
+
+	t.Run("escapes the dataset id in the URL", func(t *testing.T) {
+		var gotEscapedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			gotEscapedPath = req.URL.EscapedPath()
+			rw.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		err := PatchDataset(server.Client(), server.URL, "testToken", "some/pid", map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if gotEscapedPath != "/Datasets/some%2Fpid" {
+			t.Errorf("expected escaped dataset id in path, got: %s", gotEscapedPath)
+		}
+	})
+
+	t.Run("returns an error when the server responds with a non-2xx status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		err := PatchDataset(server.Client(), server.URL, "testToken", "testPid", map[string]interface{}{})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+}

--- a/orchestrator/completeIngest.go
+++ b/orchestrator/completeIngest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
@@ -111,4 +112,15 @@ func updateDatasetTimes(client *http.Client, APIServer string, user map[string]s
 		"endTime":      endTime.Format(time.RFC3339),
 	}
 	return datasetUtils.PatchDataset(client, APIServer, user["accessToken"], pid, meta)
+}
+
+func ExtractPidFromArgs(args []string) (string, error) {
+	if len(args) != 1 {
+		return "", fmt.Errorf("invalid number of args")
+	}
+	pid := args[0]
+	if !strings.HasPrefix(pid, "20.500.11935/") {
+		return "", fmt.Errorf("invalid pid, must start with 20.500.11935/")
+	}
+	return pid, nil
 }

--- a/orchestrator/completeIngest.go
+++ b/orchestrator/completeIngest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
@@ -31,13 +32,21 @@ func CompleteIngest(client *http.Client, APIServer string, user map[string]strin
 
 	log.Printf("Dataset with PID %s has sourceFolder %s\n", pid, sourceFolder)
 
-	fullFileArray, skippedLinks, illegalFileNames, err := gatherCompletionFileList(sourceFolder)
+	fullFileArray, startTime, endTime, skippedLinks, illegalFileNames, err := gatherCompletionFileList(sourceFolder)
 	if err != nil {
 		return err
 	}
 
 	if err := datasetIngestor.CreateOrigDatablocks(client, APIServer, fullFileArray, pid, user); err != nil {
 		return fmt.Errorf("failed to create origdatablocks for dataset %s: %w", pid, err)
+	}
+
+	if err := updateDatasetTimes(client, APIServer, user, pid, startTime, endTime); err != nil {
+		return err
+	}
+
+	if err := datasetIngestor.MarkFilesReady(client, APIServer, pid, user); err != nil {
+		return err
 	}
 
 	if skippedLinks > 0 {
@@ -82,16 +91,24 @@ func resolveEmptyDatasetSourceFolder(client *http.Client, APIServer string, user
 // counts of symlinks skipped and files excluded for illegal filenames. Symlinks are kept only
 // when they resolve to a path internal to sourceFolder ("dA" policy); this path never prompts,
 // since dataset completion is meant to run unattended.
-func gatherCompletionFileList(sourceFolder string) ([]datasetIngestor.Datafile, uint, uint, error) {
+func gatherCompletionFileList(sourceFolder string) ([]datasetIngestor.Datafile, time.Time, time.Time, uint, uint, error) {
 	skipSymlinks := "dA"
 	var skippedLinks, illegalFileNames uint
 	symlinkCallback := datasetIngestor.CreateLocalSymlinkCallbackForFileLister(&skipSymlinks, &skippedLinks)
 	filenameFilterCallback := datasetIngestor.CreateLocalFilenameFilterCallback(&illegalFileNames)
 
-	fullFileArray, _, _, _, _, _, err :=
+	fullFileArray, startTime, endTime, _, _, _, err :=
 		datasetIngestor.GetValidatedLocalFileList(sourceFolder, "", symlinkCallback, filenameFilterCallback)
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, time.Time{}, time.Time{}, 0, 0, err
 	}
-	return fullFileArray, skippedLinks, illegalFileNames, nil
+	return fullFileArray, startTime, endTime, skippedLinks, illegalFileNames, nil
+}
+
+func updateDatasetTimes(client *http.Client, APIServer string, user map[string]string, pid string, startTime time.Time, endTime time.Time) error {
+	meta := map[string]interface{}{
+		"creationTime": startTime.Format(time.RFC3339),
+		"endTime":      endTime.Format(time.RFC3339),
+	}
+	return datasetUtils.PatchDataset(client, APIServer, user["accessToken"], pid, meta)
 }

--- a/orchestrator/completeIngest.go
+++ b/orchestrator/completeIngest.go
@@ -1,0 +1,97 @@
+package orchestrator
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+)
+
+/*
+CompleteIngest defines and adds a dataset to the SciCat catalog for a dataset entry that was
+previously created without any files attached (NumberOfFiles == 0).
+
+It checks that the caller is allowed to perform the operation, that the dataset identified by
+pid exists, is empty and has a sourceFolder defined, then gathers the local file list from that
+sourceFolder and creates the corresponding origdatablocks. Symlinks are kept only when they point
+internally to the sourceFolder; filenames containing "*", "\" or three consecutive blanks are
+excluded from the dataset.
+*/
+func CompleteIngest(client *http.Client, APIServer string, user map[string]string, pid string) error {
+	if err := requireArchiveManager(user); err != nil {
+		return err
+	}
+
+	sourceFolder, err := resolveEmptyDatasetSourceFolder(client, APIServer, user, pid)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Dataset with PID %s has sourceFolder %s\n", pid, sourceFolder)
+
+	fullFileArray, skippedLinks, illegalFileNames, err := gatherCompletionFileList(sourceFolder)
+	if err != nil {
+		return err
+	}
+
+	if err := datasetIngestor.CreateOrigDatablocks(client, APIServer, fullFileArray, pid, user); err != nil {
+		return fmt.Errorf("failed to create origdatablocks for dataset %s: %w", pid, err)
+	}
+
+	if skippedLinks > 0 {
+		return &datasetIngestor.SkippedLinksWarning{Count: skippedLinks}
+	}
+	if illegalFileNames > 0 {
+		return &datasetIngestor.IllegalFileNamesWarning{Count: illegalFileNames}
+	}
+	return nil
+}
+
+// requireArchiveManager enforces that only the archiveManager account may complete an ingest.
+// Kept as a pure function so the authorization rule can be unit-tested without any client/network setup.
+func requireArchiveManager(user map[string]string) error {
+	if user["username"] != "archiveManager" {
+		return fmt.Errorf("you must be archiveManager to be allowed to complete the ingestion")
+	}
+	return nil
+}
+
+// resolveEmptyDatasetSourceFolder fetches the dataset identified by pid and validates that it is
+// in the expected pre-completion state: it exists, has no files yet, and has a sourceFolder to
+// scan. Returns that sourceFolder on success.
+func resolveEmptyDatasetSourceFolder(client *http.Client, APIServer string, user map[string]string, pid string) (string, error) {
+	dataset, missing, err := datasetUtils.GetDatasetDetails(client, APIServer, user["accessToken"], []string{pid}, "")
+	if err != nil {
+		return "", err
+	}
+	if len(missing) > 0 || len(dataset) != 1 {
+		return "", fmt.Errorf("dataset with PID %s not found", pid)
+	}
+	if dataset[0].NumberOfFiles != 0 {
+		return "", fmt.Errorf("dataset with PID %s already contains files", pid)
+	}
+	if dataset[0].SourceFolder == "" {
+		return "", fmt.Errorf("dataset with PID %s has no sourceFolder defined", pid)
+	}
+	return dataset[0].SourceFolder, nil
+}
+
+// gatherCompletionFileList scans sourceFolder and returns the resulting file list along with
+// counts of symlinks skipped and files excluded for illegal filenames. Symlinks are kept only
+// when they resolve to a path internal to sourceFolder ("dA" policy); this path never prompts,
+// since dataset completion is meant to run unattended.
+func gatherCompletionFileList(sourceFolder string) ([]datasetIngestor.Datafile, uint, uint, error) {
+	skipSymlinks := "dA"
+	var skippedLinks, illegalFileNames uint
+	symlinkCallback := datasetIngestor.CreateLocalSymlinkCallbackForFileLister(&skipSymlinks, &skippedLinks)
+	filenameFilterCallback := datasetIngestor.CreateLocalFilenameFilterCallback(&illegalFileNames)
+
+	fullFileArray, _, _, _, _, _, err :=
+		datasetIngestor.GetValidatedLocalFileList(sourceFolder, "", symlinkCallback, filenameFilterCallback)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	return fullFileArray, skippedLinks, illegalFileNames, nil
+}

--- a/orchestrator/completeIngest_test.go
+++ b/orchestrator/completeIngest_test.go
@@ -1,0 +1,217 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
+)
+
+func newDatasetDetailsServer(t *testing.T, sourceFolder string, numberOfFiles int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/Datasets":
+			rw.WriteHeader(http.StatusOK)
+			fmt.Fprintf(rw, `[{"pid":"testPid","sourceFolder":%q,"numberOfFiles":%d}]`, sourceFolder, numberOfFiles)
+		case req.Method == http.MethodPost && req.URL.Path == "/origdatablocks":
+			rw.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestCompleteIngest(t *testing.T) {
+	archiveManager := map[string]string{"username": "archiveManager", "accessToken": "testToken"}
+
+	t.Run("rejects non archiveManager users", func(t *testing.T) {
+		err := CompleteIngest(http.DefaultClient, "", map[string]string{"username": "someoneElse"}, "testPid")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("fails when the dataset already contains files", func(t *testing.T) {
+		server := newDatasetDetailsServer(t, "/some/folder", 3)
+		defer server.Close()
+
+		err := CompleteIngest(server.Client(), server.URL, archiveManager, "testPid")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("fails when the dataset has no sourceFolder", func(t *testing.T) {
+		server := newDatasetDetailsServer(t, "", 0)
+		defer server.Close()
+
+		err := CompleteIngest(server.Client(), server.URL, archiveManager, "testPid")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("fails when the dataset is not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			fmt.Fprint(rw, `[]`)
+		}))
+		defer server.Close()
+
+		err := CompleteIngest(server.Client(), server.URL, archiveManager, "testPid")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("fails when the sourceFolder contains no files", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		server := newDatasetDetailsServer(t, tempDir, 0)
+		defer server.Close()
+
+		err = CompleteIngest(server.Client(), server.URL, archiveManager, "testPid")
+		var emptyDatasetErr *datasetIngestor.EmptyDatasetError
+		if !errors.As(err, &emptyDatasetErr) {
+			t.Fatalf("expected an *EmptyDatasetError, got: %v (%T)", err, err)
+		}
+	})
+
+	t.Run("creates the origdatablock and returns a SkippedLinksWarning when links were skipped", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+		tempDirAbs, err := filepath.Abs(tempDir)
+		if err != nil {
+			t.Fatalf("failed to resolve temp directory: %s", err)
+		}
+
+		outsideDir, err := os.MkdirTemp("./", "outside")
+		if err != nil {
+			t.Fatalf("failed to create outside directory: %s", err)
+		}
+		defer os.RemoveAll(outsideDir)
+		outsideDirAbs, err := filepath.Abs(outsideDir)
+		if err != nil {
+			t.Fatalf("failed to resolve outside directory: %s", err)
+		}
+
+		externalTarget := filepath.Join(outsideDirAbs, "external.txt")
+		if err := os.WriteFile(externalTarget, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create external target file: %s", err)
+		}
+		externalLink := filepath.Join(tempDirAbs, "externalLink.txt")
+		if err := os.Symlink(externalTarget, externalLink); err != nil {
+			t.Fatalf("failed to create external symlink: %s", err)
+		}
+		// a plain file must remain so the dataset isn't also empty
+		if err := os.WriteFile(filepath.Join(tempDirAbs, "regular.txt"), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create regular file: %s", err)
+		}
+
+		var createdOrigDatablock bool
+		server := newDatasetDetailsServerWithOrigDatablockTracking(t, tempDirAbs, &createdOrigDatablock)
+		defer server.Close()
+
+		err = CompleteIngest(server.Client(), server.URL, archiveManager, "testPid")
+		var skippedLinksWarning *datasetIngestor.SkippedLinksWarning
+		if !errors.As(err, &skippedLinksWarning) {
+			t.Fatalf("expected a *SkippedLinksWarning, got: %v (%T)", err, err)
+		}
+		if skippedLinksWarning.Count != 1 {
+			t.Errorf("expected 1 skipped link, got %d", skippedLinksWarning.Count)
+		}
+		if !createdOrigDatablock {
+			t.Error("expected an origdatablock to be created even when links were skipped")
+		}
+	})
+
+	t.Run("creates the origdatablock and returns an IllegalFileNamesWarning when a filename is illegal", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		// three consecutive blanks are illegal per CreateLocalFilenameFilterCallback; unlike "*" or
+		// "\", this is a valid filename on Windows too, so the file can actually be created here.
+		illegalFilePath := filepath.Join(tempDir, "illegal   file.txt")
+		if err := os.WriteFile(illegalFilePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create illegally named file: %s", err)
+		}
+		// a plain file must remain so the dataset isn't also empty
+		if err := os.WriteFile(filepath.Join(tempDir, "regular.txt"), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create regular file: %s", err)
+		}
+
+		var createdOrigDatablock bool
+		server := newDatasetDetailsServerWithOrigDatablockTracking(t, tempDir, &createdOrigDatablock)
+		defer server.Close()
+
+		err = CompleteIngest(server.Client(), server.URL, archiveManager, "testPid")
+		var illegalFileNamesWarning *datasetIngestor.IllegalFileNamesWarning
+		if !errors.As(err, &illegalFileNamesWarning) {
+			t.Fatalf("expected an *IllegalFileNamesWarning, got: %v (%T)", err, err)
+		}
+		if illegalFileNamesWarning.Count != 1 {
+			t.Errorf("expected 1 illegal file name, got %d", illegalFileNamesWarning.Count)
+		}
+		if !createdOrigDatablock {
+			t.Error("expected an origdatablock to be created even when an illegal file name was found")
+		}
+	})
+
+	t.Run("gathers the filelist and creates the origdatablocks", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		filePath := filepath.Join(tempDir, "testfile")
+		if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create test file: %s", err)
+		}
+
+		var createdOrigDatablock bool
+		server := newDatasetDetailsServerWithOrigDatablockTracking(t, tempDir, &createdOrigDatablock)
+		defer server.Close()
+
+		if err := CompleteIngest(server.Client(), server.URL, archiveManager, "testPid"); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if !createdOrigDatablock {
+			t.Error("expected an origdatablock to be created")
+		}
+	})
+}
+
+func newDatasetDetailsServerWithOrigDatablockTracking(t *testing.T, sourceFolder string, createdOrigDatablock *bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodGet && req.URL.Path == "/Datasets":
+			rw.WriteHeader(http.StatusOK)
+			fmt.Fprintf(rw, `[{"pid":"testPid","sourceFolder":%q,"numberOfFiles":0}]`, sourceFolder)
+		case req.Method == http.MethodPost && req.URL.Path == "/origdatablocks":
+			*createdOrigDatablock = true
+			rw.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}

--- a/orchestrator/completeIngest_test.go
+++ b/orchestrator/completeIngest_test.go
@@ -1,13 +1,16 @@
 package orchestrator
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 )
@@ -19,6 +22,10 @@ func newDatasetDetailsServer(t *testing.T, sourceFolder string, numberOfFiles in
 		case req.Method == http.MethodGet && req.URL.Path == "/Datasets":
 			rw.WriteHeader(http.StatusOK)
 			fmt.Fprintf(rw, `[{"pid":"testPid","sourceFolder":%q,"numberOfFiles":%d}]`, sourceFolder, numberOfFiles)
+		case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid":
+			rw.WriteHeader(http.StatusOK)
+		case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid/datasetlifecycle":
+			rw.WriteHeader(http.StatusOK)
 		case req.Method == http.MethodPost && req.URL.Path == "/origdatablocks":
 			rw.WriteHeader(http.StatusOK)
 		default:
@@ -197,6 +204,147 @@ func TestCompleteIngest(t *testing.T) {
 			t.Error("expected an origdatablock to be created")
 		}
 	})
+
+	t.Run("aborts before updating dataset times or marking files ready when creating origdatablocks fails", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		filePath := filepath.Join(tempDir, "testfile")
+		if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create test file: %s", err)
+		}
+
+		var updatedTimes, markedFilesReady bool
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/Datasets":
+				rw.WriteHeader(http.StatusOK)
+				fmt.Fprintf(rw, `[{"pid":"testPid","sourceFolder":%q,"numberOfFiles":0}]`, tempDir)
+			case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid":
+				updatedTimes = true
+				rw.WriteHeader(http.StatusOK)
+			case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid/datasetlifecycle":
+				markedFilesReady = true
+				rw.WriteHeader(http.StatusOK)
+			case req.Method == http.MethodPost && req.URL.Path == "/origdatablocks":
+				rw.WriteHeader(http.StatusInternalServerError)
+			default:
+				t.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+				rw.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		err = CompleteIngest(server.Client(), server.URL, archiveManager, "testPid")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if updatedTimes {
+			t.Error("expected dataset times not to be updated when creating origdatablocks failed")
+		}
+		if markedFilesReady {
+			t.Error("expected files not to be marked ready when creating origdatablocks failed")
+		}
+	})
+
+	t.Run("aborts before marking files ready when updating the dataset times fails", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		filePath := filepath.Join(tempDir, "testfile")
+		if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create test file: %s", err)
+		}
+
+		var markedFilesReady bool
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/Datasets":
+				rw.WriteHeader(http.StatusOK)
+				fmt.Fprintf(rw, `[{"pid":"testPid","sourceFolder":%q,"numberOfFiles":0}]`, tempDir)
+			case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid":
+				rw.WriteHeader(http.StatusInternalServerError)
+			case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid/datasetlifecycle":
+				markedFilesReady = true
+				rw.WriteHeader(http.StatusOK)
+			case req.Method == http.MethodPost && req.URL.Path == "/origdatablocks":
+				rw.WriteHeader(http.StatusOK)
+			default:
+				t.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+				rw.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		err = CompleteIngest(server.Client(), server.URL, archiveManager, "testPid")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if markedFilesReady {
+			t.Error("expected files not to be marked ready when updating dataset times failed")
+		}
+	})
+
+	t.Run("PATCHes the dataset's creationTime and endTime derived from the scanned files", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		filePath := filepath.Join(tempDir, "testfile")
+		if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create test file: %s", err)
+		}
+
+		var patchedTimesBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/Datasets":
+				rw.WriteHeader(http.StatusOK)
+				fmt.Fprintf(rw, `[{"pid":"testPid","sourceFolder":%q,"numberOfFiles":0}]`, tempDir)
+			case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid":
+				body, _ := io.ReadAll(req.Body)
+				if err := json.Unmarshal(body, &patchedTimesBody); err != nil {
+					t.Errorf("failed to unmarshal PATCH body: %v", err)
+				}
+				rw.WriteHeader(http.StatusOK)
+			case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid/datasetlifecycle":
+				rw.WriteHeader(http.StatusOK)
+			case req.Method == http.MethodPost && req.URL.Path == "/origdatablocks":
+				rw.WriteHeader(http.StatusOK)
+			default:
+				t.Errorf("unexpected request: %s %s", req.Method, req.URL.Path)
+				rw.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		if err := CompleteIngest(server.Client(), server.URL, archiveManager, "testPid"); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		creationTime, ok := patchedTimesBody["creationTime"].(string)
+		if !ok || creationTime == "" {
+			t.Fatalf("expected a non-empty creationTime in the PATCH body, got: %v", patchedTimesBody)
+		}
+		if _, err := time.Parse(time.RFC3339, creationTime); err != nil {
+			t.Errorf("expected creationTime to be RFC3339, got %q: %v", creationTime, err)
+		}
+		endTime, ok := patchedTimesBody["endTime"].(string)
+		if !ok || endTime == "" {
+			t.Fatalf("expected a non-empty endTime in the PATCH body, got: %v", patchedTimesBody)
+		}
+		if _, err := time.Parse(time.RFC3339, endTime); err != nil {
+			t.Errorf("expected endTime to be RFC3339, got %q: %v", endTime, err)
+		}
+	})
 }
 
 func newDatasetDetailsServerWithOrigDatablockTracking(t *testing.T, sourceFolder string, createdOrigDatablock *bool) *httptest.Server {
@@ -206,6 +354,10 @@ func newDatasetDetailsServerWithOrigDatablockTracking(t *testing.T, sourceFolder
 		case req.Method == http.MethodGet && req.URL.Path == "/Datasets":
 			rw.WriteHeader(http.StatusOK)
 			fmt.Fprintf(rw, `[{"pid":"testPid","sourceFolder":%q,"numberOfFiles":0}]`, sourceFolder)
+		case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid":
+			rw.WriteHeader(http.StatusOK)
+		case req.Method == http.MethodPatch && req.URL.Path == "/Datasets/testPid/datasetlifecycle":
+			rw.WriteHeader(http.StatusOK)
 		case req.Method == http.MethodPost && req.URL.Path == "/origdatablocks":
 			*createdOrigDatablock = true
 			rw.WriteHeader(http.StatusOK)

--- a/orchestrator/completeIngest_test.go
+++ b/orchestrator/completeIngest_test.go
@@ -347,6 +347,39 @@ func TestCompleteIngest(t *testing.T) {
 	})
 }
 
+func TestExtractPidFromArgs(t *testing.T) {
+	t.Run("returns the pid when a single valid arg is given", func(t *testing.T) {
+		pid, err := ExtractPidFromArgs([]string{"20.500.11935/testPid"})
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if pid != "20.500.11935/testPid" {
+			t.Errorf("expected pid %q, got %q", "20.500.11935/testPid", pid)
+		}
+	})
+
+	t.Run("fails when no args are given", func(t *testing.T) {
+		_, err := ExtractPidFromArgs([]string{})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("fails when more than one arg is given", func(t *testing.T) {
+		_, err := ExtractPidFromArgs([]string{"20.500.11935/testPid", "extra"})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("fails when the pid does not have the expected prefix", func(t *testing.T) {
+		_, err := ExtractPidFromArgs([]string{"someOtherPid"})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+}
+
 func newDatasetDetailsServerWithOrigDatablockTracking(t *testing.T, sourceFolder string, createdOrigDatablock *bool) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
This pr is an easier implementation of a dedicated completeIngest command available to archiveManager only and that can take one single datasetId as input, together with the token and the env to run against.

It will create origs if missing starting from a datasetId.

It introduces an `orchestrator` folder where to put logic executed by the cobra calls but which needs to be tested or benefits from single responsability or logical splits