### PR TITLE
feat: add remote-file flag for remote ingestion

### DIFF
--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -323,7 +323,7 @@ For Windows you need instead to specify -user username:password on the command l
 			}
 			fullFileArray := make([]datasetIngestor.Datafile, 0)
 			if remoteFilesFlag {
-				datasetIngestor.UpdateStaticMetadataFields(client, APIServer, user, metaDataMap, tapecopies)
+				orchestrator.PrepareRemoteDataset(client, APIServer, user, originalMap, metaDataMap, tapecopies)
 			} else {
 				var err error
 				fullFileArray, err = orchestrator.PrepareDataset(client, APIServer, user, originalMap, metaDataMap, tapecopies,
@@ -372,24 +372,13 @@ For Windows you need instead to specify -user username:password on the command l
 			// === ingest dataset ===
 			if ingestFlag {
 				// create ingest . For decentral case delay setting status to archivable until data is copied
-				archivable := false
 				if _, ok := metaDataMap["datasetlifecycle"]; !ok {
 					metaDataMap["datasetlifecycle"] = map[string]interface{}{}
 				}
-				if copyFlag { // IDEA: maybe add a flag to indicate that we want to copy later?
-					// do not override existing fields
-					metaDataMap["datasetlifecycle"].(map[string]interface{})["isOnCentralDisk"] = false
-					metaDataMap["datasetlifecycle"].(map[string]interface{})["archiveStatusMessage"] = "filesNotYetAvailable"
-					metaDataMap["datasetlifecycle"].(map[string]interface{})["archivable"] = false
-				} else {
-					archivable = true
-					metaDataMap["datasetlifecycle"].(map[string]interface{})["isOnCentralDisk"] = true
-					metaDataMap["datasetlifecycle"].(map[string]interface{})["archiveStatusMessage"] = "datasetCreated"
-					metaDataMap["datasetlifecycle"].(map[string]interface{})["archivable"] = true
-				}
-				if remoteFilesFlag {
-					metaDataMap["datasetlifecycle"].(map[string]interface{})["archiveStatusMessage"] = "origDatablocksNotYetAvailable"
-				}
+				archivable, metaArchivable, isOnCentralDisk, archiveStatusMessage := orchestrator.DetermineDatasetLifecycle(copyFlag, remoteFilesFlag)
+				metaDataMap["datasetlifecycle"].(map[string]interface{})["isOnCentralDisk"] = isOnCentralDisk
+				metaDataMap["datasetlifecycle"].(map[string]interface{})["archiveStatusMessage"] = archiveStatusMessage
+				metaDataMap["datasetlifecycle"].(map[string]interface{})["archivable"] = metaArchivable
 				log.Println("Ingesting dataset...")
 				datasetId, err := datasetIngestor.IngestDataset(client, APIServer, metaDataMap, fullFileArray, user)
 				if err != nil {

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -326,7 +326,7 @@ For Windows you need instead to specify -user username:password on the command l
 				orchestrator.PrepareRemoteDataset(client, APIServer, user, originalMap, metaDataMap, tapecopies)
 			} else {
 				var err error
-				fullFileArray, err = orchestrator.PrepareDataset(client, APIServer, user, originalMap, metaDataMap, tapecopies,
+				fullFileArray, err = orchestrator.PrepareDatasetAndUpdateCounts(client, APIServer, user, originalMap, metaDataMap, tapecopies,
 					datasetSourceFolder, datasetFileListTxt, localSymlinkCallback, localFilepathFilterCallback,
 					&emptyDatasets, &tooLargeDatasets)
 				if err != nil {
@@ -347,7 +347,7 @@ For Windows you need instead to specify -user username:password on the command l
 				// check if data is accesible at archive server, unless beamline account (assumed to be centrally available always)
 				// and unless (no)copy flag defined via command line
 				if checkCentralAvailability {
-					newCopyFlag, err := orchestrator.ResolveCentralAvailability(user["username"], RSYNCServer, datasetSourceFolder, os.Stdout,
+					newCopyFlag, err := orchestrator.ResolveCentralAvailability(user["username"], RSYNCServer, datasetSourceFolder,
 						copyFlag, accessGroups, noninteractiveFlag, func() bool {
 							log.Printf("Do you want to continue (Y/n)? ")
 							scanner.Scan()

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -18,6 +17,7 @@ import (
 	"github.com/paulscherrerinstitute/scicat-cli/v3/cmd/cliutils"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+	"github.com/paulscherrerinstitute/scicat-cli/v3/orchestrator"
 	"github.com/spf13/cobra"
 )
 
@@ -81,6 +81,11 @@ For Windows you need instead to specify -user username:password on the command l
 		addCaption := cliutils.GetCobraStringFlag(cmd, "addcaption")
 		showVersion := cliutils.GetCobraBoolFlag(cmd, "version")
 		globusCfgFlag := cliutils.GetCobraStringFlag(cmd, "globus-cfg")
+		remoteFilesFlag := cliutils.GetCobraBoolFlag(cmd, "remote-files")
+
+		if remoteFilesFlag {
+			nocopyFlag = true
+		}
 
 		// TODO: read in CFG!
 
@@ -143,6 +148,7 @@ For Windows you need instead to specify -user username:password on the command l
 				"addattachment":       addAttachment,
 				"addcaption":          addCaption,
 				"version":             showVersion,
+				"remote-files":        remoteFilesFlag,
 			})
 			return
 		}
@@ -309,75 +315,60 @@ For Windows you need instead to specify -user username:password on the command l
 
 			// === get filelist of dataset ===
 			log.Printf("Getting filelist for \"%s\"...\n", datasetSourceFolder)
-			fullFileArray, startTime, endTime, owner, numFiles, totalSize, err :=
-				datasetIngestor.GetValidatedLocalFileList(datasetSourceFolder, datasetFileListTxt, localSymlinkCallback, localFilepathFilterCallback)
-			if err != nil {
-				var emptyDatasetErr *datasetIngestor.EmptyDatasetError
-				var tooManyFilesErr *datasetIngestor.TooManyFilesError
-				switch {
-				case errors.As(err, &emptyDatasetErr):
-					emptyDatasets++
-				case errors.As(err, &tooManyFilesErr):
-					tooLargeDatasets++
-				default:
-					log.Fatalf("Can't gather the filelist of \"%s\": %v", datasetSourceFolder, err)
-				}
-				color.Set(color.FgRed)
-				log.Println(err)
-				color.Unset()
-				continue
-			}
-			log.Println("File list collected.")
-			//log.Printf("full fileListing: %v\n Start and end time: %s %s\n ", fullFileArray, startTime, endTime)
-			log.Printf("The dataset contains %v files with a total size of %v bytes.\n", numFiles, totalSize)
-
 			// NOTE: only tapecopies=1 or 2 does something if set.
 			if tapecopies == 2 {
 				color.Set(color.FgYellow)
 				log.Printf("Note: this dataset, if archived, will be copied to two tape copies")
 				color.Unset()
 			}
-			// === update metadata ===
-			datasetIngestor.UpdateMetaData(client, APIServer, user, originalMap, metaDataMap, startTime, endTime, owner, tapecopies)
-			pretty, _ := json.MarshalIndent(metaDataMap, "", "    ")
-
-			log.Printf("Updated metadata object:\n%s\n", pretty)
-
-			// === check central availability of data ===
-			// check if data is accesible at archive server, unless beamline account (assumed to be centrally available always)
-			// and unless (no)copy flag defined via command line
-			if checkCentralAvailability {
-				log.Println("Checking if data is centrally available...")
-				sshErr, otherErr := datasetIngestor.CheckDataCentrallyAvailableSsh(user["username"], RSYNCServer, datasetSourceFolder, os.Stdout)
-				if otherErr != nil {
-					log.Fatalln("Cannot check if data is centrally available:", otherErr)
-				}
-				// if the ssh command's error is not nil, the dataset is *likely* to be not centrally available (maybe should check the error returned)
-				if sshErr != nil {
-					color.Set(color.FgYellow)
-					log.Printf("The source folder %v is not centrally available.\nThe data must first be copied.\n ", datasetSourceFolder)
-					color.Unset()
-					copyFlag = true
-					// check if user account
-					if len(accessGroups) == 0 {
+			fullFileArray := make([]datasetIngestor.Datafile, 0)
+			if remoteFilesFlag {
+				datasetIngestor.UpdateStaticMetadataFields(client, APIServer, user, metaDataMap, tapecopies)
+			} else {
+				var err error
+				fullFileArray, err = orchestrator.PrepareDataset(client, APIServer, user, originalMap, metaDataMap, tapecopies,
+					datasetSourceFolder, datasetFileListTxt, localSymlinkCallback, localFilepathFilterCallback,
+					&emptyDatasets, &tooLargeDatasets)
+				if err != nil {
+					var emptyDatasetErr *datasetIngestor.EmptyDatasetError
+					var tooManyFilesErr *datasetIngestor.TooManyFilesError
+					if errors.As(err, &emptyDatasetErr) || errors.As(err, &tooManyFilesErr) {
 						color.Set(color.FgRed)
-						log.Println("For copying, you must use a personal account. Beamline accounts are not supported.")
+						log.Println(err)
 						color.Unset()
-						os.Exit(1)
+						continue
 					}
-					if !noninteractiveFlag {
-						log.Printf("Do you want to continue (Y/n)? ")
-						scanner.Scan()
-						continueFlag := scanner.Text()
-						if continueFlag == "n" {
-							log.Fatalln("Further ingests interrupted because copying is needed, but no copy wanted.")
+					color.Set(color.FgRed)
+					log.Print(err)
+					color.Unset()
+					os.Exit(1)
+				}
+
+				// check if data is accesible at archive server, unless beamline account (assumed to be centrally available always)
+				// and unless (no)copy flag defined via command line
+				if checkCentralAvailability {
+					newCopyFlag, err := orchestrator.ResolveCentralAvailability(user["username"], RSYNCServer, datasetSourceFolder, os.Stdout,
+						copyFlag, accessGroups, noninteractiveFlag, func() bool {
+							log.Printf("Do you want to continue (Y/n)? ")
+							scanner.Scan()
+							return scanner.Text() != "n"
+						})
+					if err != nil {
+						var notCentrallyAvailableWarning *orchestrator.NotCentrallyAvailableWarning
+						if errors.As(err, &notCentrallyAvailableWarning) {
+							color.Set(color.FgYellow)
+							log.Print(err)
+							color.Unset()
+						} else {
+							color.Set(color.FgRed)
+							log.Print(err)
+							color.Unset()
+							os.Exit(1)
 						}
 					}
-				} else {
-					log.Println("Data is present centrally.")
+					copyFlag = newCopyFlag
 				}
 			}
-
 			// === ingest dataset ===
 			if ingestFlag {
 				// create ingest . For decentral case delay setting status to archivable until data is copied
@@ -395,6 +386,9 @@ For Windows you need instead to specify -user username:password on the command l
 					metaDataMap["datasetlifecycle"].(map[string]interface{})["isOnCentralDisk"] = true
 					metaDataMap["datasetlifecycle"].(map[string]interface{})["archiveStatusMessage"] = "datasetCreated"
 					metaDataMap["datasetlifecycle"].(map[string]interface{})["archivable"] = true
+				}
+				if remoteFilesFlag {
+					metaDataMap["datasetlifecycle"].(map[string]interface{})["archiveStatusMessage"] = "origDatablocksNotYetAvailable"
 				}
 				log.Println("Ingesting dataset...")
 				datasetId, err := datasetIngestor.IngestDataset(client, APIServer, metaDataMap, fullFileArray, user)
@@ -540,7 +534,9 @@ func init() {
 	datasetIngestorCmd.Flags().String("addattachment", "", "Filename of image to attach (single dataset case only)")
 	datasetIngestorCmd.Flags().String("addcaption", "", "Optional caption to be stored with attachment (single dataset case only)")
 	datasetIngestorCmd.Flags().String("globus-cfg", "", "Override globus transfer config file location [default: globus.yaml next to executable]")
+	datasetIngestorCmd.Flags().Bool("remote-files", false, "Defines if files should be accessed remotely instead of locally (i.e. your data is not locally available and therefore needs to be accessed remotely ='remote' case).")
 
 	datasetIngestorCmd.MarkFlagsMutuallyExclusive("testenv", "devenv", "localenv", "tunnelenv")
 	datasetIngestorCmd.MarkFlagsMutuallyExclusive("nocopy", "copy")
+	datasetIngestorCmd.MarkFlagsMutuallyExclusive("remote-files", "copy")
 }

--- a/datasetIngestor/checkDataCentrallyAvailableSsh.go
+++ b/datasetIngestor/checkDataCentrallyAvailableSsh.go
@@ -10,20 +10,18 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// Goos is a variable that points to runtime.GOOS, allowing it to be replaced in tests
-// (including from other packages, e.g. orchestrator).
-var Goos = runtime.GOOS
+// goos is a variable that points to runtime.GOOS, allowing it to be replaced in tests.
+var goos = runtime.GOOS
 
 // execCommand is a variable that points to exec.Command, allowing it to be replaced in tests.
 var execCommand = exec.Command
 
-// NewDumbClientFunc is a variable that points to NewDumbClient, allowing it to be replaced in tests
-// (including from other packages, e.g. orchestrator).
-var NewDumbClientFunc = NewDumbClient
+// newDumbClient is a variable that points to NewDumbClient, allowing it to be replaced in tests.
+var newDumbClient = NewDumbClient
 
-// CheckRemoteDirectoryFunc is a variable that points to Client.CheckRemoteDirectory, allowing it to be
-// replaced in tests (including from other packages, e.g. orchestrator).
-var CheckRemoteDirectoryFunc = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
+// checkRemoteDirectory is a variable that points to Client.CheckRemoteDirectory, allowing it to be
+// replaced in tests.
+var checkRemoteDirectory = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
 	return c.CheckRemoteDirectory(sourceFolder, sshOutput)
 }
 
@@ -37,10 +35,9 @@ var isRemoteDirectoryNotFoundExec = func(err error) bool {
 	return false
 }
 
-// IsRemoteDirectoryNotFound classifies pure-Go SSH client errors where remote "test -d"
+// isRemoteDirectoryNotFoundSsh classifies pure-Go SSH client errors where remote "test -d"
 // evaluated to false (exit status 1), as opposed to a connection/authentication failure or another error.
-// (exported so it can be replaced in tests from other packages, e.g. orchestrator).
-var IsRemoteDirectoryNotFound = func(err error) bool {
+var isRemoteDirectoryNotFoundSsh = func(err error) bool {
 	var exitErr *ssh.ExitError
 	if errors.As(err, &exitErr) {
 		return exitErr.ExitStatus() == 1
@@ -65,9 +62,9 @@ Returned values:
   - otherErr - other error that prevents the check from being executed
 */
 func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourceFolder string, sshOutput io.Writer) (sshErr error, otherErr error) {
-	switch Goos {
+	switch goos {
 	case "windows":
-		client, err := NewDumbClientFunc(username, "", ARCHIVEServer)
+		client, err := newDumbClient(username, "", ARCHIVEServer)
 		if err != nil {
 			return nil, err
 		}
@@ -75,11 +72,11 @@ func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourc
 			defer client.SshClient.Close()
 		}
 
-		err = CheckRemoteDirectoryFunc(client, sourceFolder, sshOutput)
+		err = checkRemoteDirectory(client, sourceFolder, sshOutput)
 		if err == nil {
 			return nil, nil
 		}
-		if IsRemoteDirectoryNotFound(err) {
+		if isRemoteDirectoryNotFoundSsh(err) {
 			return err, nil
 		}
 		return nil, err

--- a/datasetIngestor/checkDataCentrallyAvailableSsh.go
+++ b/datasetIngestor/checkDataCentrallyAvailableSsh.go
@@ -10,17 +10,20 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// goos is a variable that points to runtime.GOOS, allowing it to be replaced in tests.
-var goos = runtime.GOOS
+// Goos is a variable that points to runtime.GOOS, allowing it to be replaced in tests
+// (including from other packages, e.g. orchestrator).
+var Goos = runtime.GOOS
 
 // execCommand is a variable that points to exec.Command, allowing it to be replaced in tests.
 var execCommand = exec.Command
 
-// newDumbClient is a variable that points to NewDumbClient, allowing it to be replaced in tests.
-var newDumbClient = NewDumbClient
+// NewDumbClientFunc is a variable that points to NewDumbClient, allowing it to be replaced in tests
+// (including from other packages, e.g. orchestrator).
+var NewDumbClientFunc = NewDumbClient
 
-// checkRemoteDirectory is a variable that points to Client.CheckRemoteDirectory, allowing it to be replaced in tests.
-var checkRemoteDirectory = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
+// CheckRemoteDirectoryFunc is a variable that points to Client.CheckRemoteDirectory, allowing it to be
+// replaced in tests (including from other packages, e.g. orchestrator).
+var CheckRemoteDirectoryFunc = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
 	return c.CheckRemoteDirectory(sourceFolder, sshOutput)
 }
 
@@ -34,9 +37,10 @@ var isRemoteDirectoryNotFoundExec = func(err error) bool {
 	return false
 }
 
-// isRemoteDirectoryNotFoundSsh classifies pure-Go SSH client errors where remote "test -d"
+// IsRemoteDirectoryNotFound classifies pure-Go SSH client errors where remote "test -d"
 // evaluated to false (exit status 1), as opposed to a connection/authentication failure or another error.
-var isRemoteDirectoryNotFoundSsh = func(err error) bool {
+// (exported so it can be replaced in tests from other packages, e.g. orchestrator).
+var IsRemoteDirectoryNotFound = func(err error) bool {
 	var exitErr *ssh.ExitError
 	if errors.As(err, &exitErr) {
 		return exitErr.ExitStatus() == 1
@@ -61,9 +65,9 @@ Returned values:
   - otherErr - other error that prevents the check from being executed
 */
 func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourceFolder string, sshOutput io.Writer) (sshErr error, otherErr error) {
-	switch goos {
+	switch Goos {
 	case "windows":
-		client, err := newDumbClient(username, "", ARCHIVEServer)
+		client, err := NewDumbClientFunc(username, "", ARCHIVEServer)
 		if err != nil {
 			return nil, err
 		}
@@ -71,11 +75,11 @@ func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourc
 			defer client.SshClient.Close()
 		}
 
-		err = checkRemoteDirectory(client, sourceFolder, sshOutput)
+		err = CheckRemoteDirectoryFunc(client, sourceFolder, sshOutput)
 		if err == nil {
 			return nil, nil
 		}
-		if isRemoteDirectoryNotFoundSsh(err) {
+		if IsRemoteDirectoryNotFound(err) {
 			return err, nil
 		}
 		return nil, err

--- a/datasetIngestor/checkDataCentrallyAvailableSsh_test.go
+++ b/datasetIngestor/checkDataCentrallyAvailableSsh_test.go
@@ -92,9 +92,9 @@ func TestCheckDataCentrallyAvailable(t *testing.T) {
 		},
 	}
 
-	oldGoos := Goos
-	t.Cleanup(func() { Goos = oldGoos })
-	Goos = "linux"
+	oldGoos := goos
+	t.Cleanup(func() { goos = oldGoos })
+	goos = "linux"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -114,9 +114,9 @@ func TestCheckDataCentrallyAvailable(t *testing.T) {
 }
 
 func TestCheckDataCentrallyAvailable_NoSshBinary(t *testing.T) {
-	oldGoos := Goos
-	t.Cleanup(func() { Goos = oldGoos })
-	Goos = "linux"
+	oldGoos := goos
+	t.Cleanup(func() { goos = oldGoos })
+	goos = "linux"
 
 	oldPath := os.Getenv("PATH")
 	t.Cleanup(func() { os.Setenv("PATH", oldPath) })
@@ -155,18 +155,18 @@ func TestCheckDataCentrallyAvailable_Windows(t *testing.T) {
 		},
 	}
 
-	oldGoos := Goos
-	oldNewDumbClient := NewDumbClientFunc
-	oldCheckRemoteDirectory := CheckRemoteDirectoryFunc
-	oldIsRemoteDirectoryNotFound := IsRemoteDirectoryNotFound
+	oldGoos := goos
+	oldNewDumbClient := newDumbClient
+	oldCheckRemoteDirectory := checkRemoteDirectory
+	oldIsRemoteDirectoryNotFound := isRemoteDirectoryNotFoundSsh
 	t.Cleanup(func() {
-		Goos = oldGoos
-		NewDumbClientFunc = oldNewDumbClient
-		CheckRemoteDirectoryFunc = oldCheckRemoteDirectory
-		IsRemoteDirectoryNotFound = oldIsRemoteDirectoryNotFound
+		goos = oldGoos
+		newDumbClient = oldNewDumbClient
+		checkRemoteDirectory = oldCheckRemoteDirectory
+		isRemoteDirectoryNotFoundSsh = oldIsRemoteDirectoryNotFound
 	})
-	Goos = "windows"
-	NewDumbClientFunc = func(username, password, server string) (*Client, error) {
+	goos = "windows"
+	newDumbClient = func(username, password, server string) (*Client, error) {
 		return &Client{}, nil
 	}
 
@@ -177,10 +177,10 @@ func TestCheckDataCentrallyAvailable_Windows(t *testing.T) {
 				returnError = errors.New(tt.errMsg)
 			}
 
-			CheckRemoteDirectoryFunc = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
+			checkRemoteDirectory = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
 				return returnError
 			}
-			IsRemoteDirectoryNotFound = func(err error) bool {
+			isRemoteDirectoryNotFoundSsh = func(err error) bool {
 				return tt.isNotFoundErr
 			}
 
@@ -196,14 +196,14 @@ func TestCheckDataCentrallyAvailable_Windows(t *testing.T) {
 }
 
 func TestCheckDataCentrallyAvailable_Windows_NewDumbClientError(t *testing.T) {
-	oldGoos := Goos
-	oldNewDumbClient := NewDumbClientFunc
+	oldGoos := goos
+	oldNewDumbClient := newDumbClient
 	t.Cleanup(func() {
-		Goos = oldGoos
-		NewDumbClientFunc = oldNewDumbClient
+		goos = oldGoos
+		newDumbClient = oldNewDumbClient
 	})
-	Goos = "windows"
-	NewDumbClientFunc = func(username, password, server string) (*Client, error) {
+	goos = "windows"
+	newDumbClient = func(username, password, server string) (*Client, error) {
 		return nil, errors.New("dial failure")
 	}
 

--- a/datasetIngestor/checkDataCentrallyAvailableSsh_test.go
+++ b/datasetIngestor/checkDataCentrallyAvailableSsh_test.go
@@ -92,9 +92,9 @@ func TestCheckDataCentrallyAvailable(t *testing.T) {
 		},
 	}
 
-	oldGoos := goos
-	t.Cleanup(func() { goos = oldGoos })
-	goos = "linux"
+	oldGoos := Goos
+	t.Cleanup(func() { Goos = oldGoos })
+	Goos = "linux"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -114,9 +114,9 @@ func TestCheckDataCentrallyAvailable(t *testing.T) {
 }
 
 func TestCheckDataCentrallyAvailable_NoSshBinary(t *testing.T) {
-	oldGoos := goos
-	t.Cleanup(func() { goos = oldGoos })
-	goos = "linux"
+	oldGoos := Goos
+	t.Cleanup(func() { Goos = oldGoos })
+	Goos = "linux"
 
 	oldPath := os.Getenv("PATH")
 	t.Cleanup(func() { os.Setenv("PATH", oldPath) })
@@ -155,18 +155,18 @@ func TestCheckDataCentrallyAvailable_Windows(t *testing.T) {
 		},
 	}
 
-	oldGoos := goos
-	oldNewDumbClient := newDumbClient
-	oldCheckRemoteDirectory := checkRemoteDirectory
-	oldIsRemoteDirectoryNotFoundSsh := isRemoteDirectoryNotFoundSsh
+	oldGoos := Goos
+	oldNewDumbClient := NewDumbClientFunc
+	oldCheckRemoteDirectory := CheckRemoteDirectoryFunc
+	oldIsRemoteDirectoryNotFound := IsRemoteDirectoryNotFound
 	t.Cleanup(func() {
-		goos = oldGoos
-		newDumbClient = oldNewDumbClient
-		checkRemoteDirectory = oldCheckRemoteDirectory
-		isRemoteDirectoryNotFoundSsh = oldIsRemoteDirectoryNotFoundSsh
+		Goos = oldGoos
+		NewDumbClientFunc = oldNewDumbClient
+		CheckRemoteDirectoryFunc = oldCheckRemoteDirectory
+		IsRemoteDirectoryNotFound = oldIsRemoteDirectoryNotFound
 	})
-	goos = "windows"
-	newDumbClient = func(username, password, server string) (*Client, error) {
+	Goos = "windows"
+	NewDumbClientFunc = func(username, password, server string) (*Client, error) {
 		return &Client{}, nil
 	}
 
@@ -177,10 +177,10 @@ func TestCheckDataCentrallyAvailable_Windows(t *testing.T) {
 				returnError = errors.New(tt.errMsg)
 			}
 
-			checkRemoteDirectory = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
+			CheckRemoteDirectoryFunc = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
 				return returnError
 			}
-			isRemoteDirectoryNotFoundSsh = func(err error) bool {
+			IsRemoteDirectoryNotFound = func(err error) bool {
 				return tt.isNotFoundErr
 			}
 
@@ -196,14 +196,14 @@ func TestCheckDataCentrallyAvailable_Windows(t *testing.T) {
 }
 
 func TestCheckDataCentrallyAvailable_Windows_NewDumbClientError(t *testing.T) {
-	oldGoos := goos
-	oldNewDumbClient := newDumbClient
+	oldGoos := Goos
+	oldNewDumbClient := NewDumbClientFunc
 	t.Cleanup(func() {
-		goos = oldGoos
-		newDumbClient = oldNewDumbClient
+		Goos = oldGoos
+		NewDumbClientFunc = oldNewDumbClient
 	})
-	goos = "windows"
-	newDumbClient = func(username, password, server string) (*Client, error) {
+	Goos = "windows"
+	NewDumbClientFunc = func(username, password, server string) (*Client, error) {
 		return nil, errors.New("dial failure")
 	}
 

--- a/datasetIngestor/getLocalFileList_test.go
+++ b/datasetIngestor/getLocalFileList_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -141,6 +142,44 @@ func TestGetValidatedLocalFileList(t *testing.T) {
 		var emptyDatasetErr *EmptyDatasetError
 		if errors.As(err, &emptyDatasetErr) {
 			t.Fatalf("expected a plain gathering error, not an *EmptyDatasetError: %v", err)
+		}
+	})
+
+	t.Run("returns a TooManyFilesError when the dataset exceeds TOTAL_MAXFILES", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("./", "test")
+		if err != nil {
+			t.Fatalf("Failed to create temp directory: %s", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		filePath := filepath.Join(tempDir, "testfile")
+		if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %s", err)
+		}
+
+		// GetLocalFileList walks each line of the file listing independently, so listing the
+		// same real file more times than TOTAL_MAXFILES allows drives numFiles past the limit
+		// without creating hundreds of thousands of files on disk (which is prohibitively slow,
+		// especially on Windows with real-time antivirus scanning).
+		var listing strings.Builder
+		for i := 0; i < TOTAL_MAXFILES+1; i++ {
+			listing.WriteString("testfile\n")
+		}
+		listingPath := filepath.Join(tempDir, "filelisting.txt")
+		if err := os.WriteFile(listingPath, []byte(listing.String()), 0644); err != nil {
+			t.Fatalf("failed to write file listing: %s", err)
+		}
+
+		_, _, _, _, numFiles, _, err := GetValidatedLocalFileList(tempDir, listingPath, nil, nil)
+		var tooManyErr *TooManyFilesError
+		if !errors.As(err, &tooManyErr) {
+			t.Fatalf("expected a *TooManyFilesError, got: %v (%T)", err, err)
+		}
+		if tooManyErr.MaxFiles != TOTAL_MAXFILES {
+			t.Errorf("MaxFiles = %d, want %d", tooManyErr.MaxFiles, TOTAL_MAXFILES)
+		}
+		if numFiles != TOTAL_MAXFILES+1 {
+			t.Errorf("numFiles = %d, want %d", numFiles, TOTAL_MAXFILES+1)
 		}
 	})
 }

--- a/datasetIngestor/updateMetaData.go
+++ b/datasetIngestor/updateMetaData.go
@@ -108,7 +108,7 @@ The function does not return a value.
 func UpdateMetaData(client *http.Client, APIServer string, user map[string]string,
 	originalMap map[string]string, metaDataMap map[string]interface{}, startTime time.Time, endTime time.Time, owner string, tapecopies int) {
 	updateMetadataFromFileFields(originalMap, metaDataMap, startTime, endTime, owner)
-	UpdateStaticMetadataFields(client, APIServer, user, metaDataMap, tapecopies)
+	updateStaticMetadataFields(client, APIServer, user, metaDataMap, tapecopies)
 }
 
 func updateMetadataFromFileFields(originalMap map[string]string, metaDataMap map[string]interface{}, startTime time.Time, endTime time.Time, owner string) {
@@ -120,7 +120,7 @@ func updateMetadataFromFileFields(originalMap map[string]string, metaDataMap map
 	}
 }
 
-func UpdateStaticMetadataFields(client *http.Client, APIServer string, user map[string]string, metaDataMap map[string]interface{}, tapecopies int) {
+func updateStaticMetadataFields(client *http.Client, APIServer string, user map[string]string, metaDataMap map[string]interface{}, tapecopies int) {
 	addFieldIfNotExists(metaDataMap, "license", "CC BY-SA 4.0")
 	addFieldIfNotExists(metaDataMap, "isPublished", false)
 	updateClassificationField(client, APIServer, user, metaDataMap, tapecopies)

--- a/datasetIngestor/updateMetaData.go
+++ b/datasetIngestor/updateMetaData.go
@@ -107,16 +107,22 @@ The function does not return a value.
 */
 func UpdateMetaData(client *http.Client, APIServer string, user map[string]string,
 	originalMap map[string]string, metaDataMap map[string]interface{}, startTime time.Time, endTime time.Time, owner string, tapecopies int) {
+	updateMetadataFromFileFields(originalMap, metaDataMap, startTime, endTime, owner)
+	UpdateStaticMetadataFields(client, APIServer, user, metaDataMap, tapecopies)
+}
+
+func updateMetadataFromFileFields(originalMap map[string]string, metaDataMap map[string]interface{}, startTime time.Time, endTime time.Time, owner string) {
 	updateFieldIfDummy(metaDataMap, originalMap, "creationTime", DUMMY_TIME, startTime)
 	updateFieldIfDummy(metaDataMap, originalMap, "ownerGroup", DUMMY_OWNER, owner)
 
 	if metaDataMap["type"] == "raw" {
 		updateFieldIfDummy(metaDataMap, originalMap, "endTime", DUMMY_TIME, endTime)
 	}
+}
 
+func UpdateStaticMetadataFields(client *http.Client, APIServer string, user map[string]string, metaDataMap map[string]interface{}, tapecopies int) {
 	addFieldIfNotExists(metaDataMap, "license", "CC BY-SA 4.0")
 	addFieldIfNotExists(metaDataMap, "isPublished", false)
-
 	updateClassificationField(client, APIServer, user, metaDataMap, tapecopies)
 }
 

--- a/orchestrator/completeIngest.go
+++ b/orchestrator/completeIngest.go
@@ -26,14 +26,14 @@ func CompleteIngest(client *http.Client, APIServer string, user map[string]strin
 		return err
 	}
 
-	sourceFolder, err := resolveEmptyDatasetSourceFolder(client, APIServer, user, pid)
+	dataset, err := resolveEmptyDatasetSourceFolder(client, APIServer, user, pid)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("Dataset with PID %s has sourceFolder %s\n", pid, sourceFolder)
+	log.Printf("Dataset with PID %s has sourceFolder %s\n", pid, dataset.SourceFolder)
 
-	fullFileArray, startTime, endTime, skippedLinks, illegalFileNames, err := gatherCompletionFileList(sourceFolder)
+	fullFileArray, startTime, endTime, skippedLinks, illegalFileNames, err := gatherCompletionFileList(dataset.SourceFolder)
 	if err != nil {
 		return err
 	}
@@ -71,21 +71,21 @@ func requireArchiveManager(user map[string]string) error {
 // resolveEmptyDatasetSourceFolder fetches the dataset identified by pid and validates that it is
 // in the expected pre-completion state: it exists, has no files yet, and has a sourceFolder to
 // scan. Returns that sourceFolder on success.
-func resolveEmptyDatasetSourceFolder(client *http.Client, APIServer string, user map[string]string, pid string) (string, error) {
+func resolveEmptyDatasetSourceFolder(client *http.Client, APIServer string, user map[string]string, pid string) (datasetUtils.Dataset, error) {
 	dataset, missing, err := datasetUtils.GetDatasetDetails(client, APIServer, user["accessToken"], []string{pid}, "")
 	if err != nil {
-		return "", err
+		return datasetUtils.Dataset{}, err
 	}
 	if len(missing) > 0 || len(dataset) != 1 {
-		return "", fmt.Errorf("dataset with PID %s not found", pid)
+		return datasetUtils.Dataset{}, fmt.Errorf("dataset with PID %s not found", pid)
 	}
 	if dataset[0].NumberOfFiles != 0 {
-		return "", fmt.Errorf("dataset with PID %s already contains files", pid)
+		return datasetUtils.Dataset{}, fmt.Errorf("dataset with PID %s already contains files", pid)
 	}
 	if dataset[0].SourceFolder == "" {
-		return "", fmt.Errorf("dataset with PID %s has no sourceFolder defined", pid)
+		return datasetUtils.Dataset{}, fmt.Errorf("dataset with PID %s has no sourceFolder defined", pid)
 	}
-	return dataset[0].SourceFolder, nil
+	return dataset[0], nil
 }
 
 // gatherCompletionFileList scans sourceFolder and returns the resulting file list along with

--- a/orchestrator/datasetIngestor.go
+++ b/orchestrator/datasetIngestor.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
@@ -20,14 +20,14 @@ import (
 // must be skipped (not fatal, no os.Exit); anything else is a hard failure gathering the local
 // file list. emptyDatasets/tooLargeDatasets are incremented to match whichever of those two
 // errors is returned.
-func PrepareDataset(client *http.Client, APIServer string, user map[string]string,
+func PrepareDatasetAndUpdateCounts(client *http.Client, APIServer string, user map[string]string,
 	originalMap map[string]string, metaDataMap map[string]interface{}, tapecopies int,
 	datasetSourceFolder string, datasetFileListTxt string,
 	symlinkCallback func(symlinkPath string, sourceFolder string) (bool, error),
 	filenameCheckCallback func(filepath string) bool,
 	emptyDatasets *int, tooLargeDatasets *int) (fullFileArray []datasetIngestor.Datafile, err error) {
-	fullFileArray, startTime, endTime, owner, numFiles, totalSize, err :=
-		datasetIngestor.GetValidatedLocalFileList(datasetSourceFolder, datasetFileListTxt, symlinkCallback, filenameCheckCallback)
+	fullFileArray, err = prepareDataset(client, APIServer, user, originalMap, metaDataMap, tapecopies,
+		datasetSourceFolder, datasetFileListTxt, symlinkCallback, filenameCheckCallback)
 	if err != nil {
 		var emptyDatasetErr *datasetIngestor.EmptyDatasetError
 		var tooManyFilesErr *datasetIngestor.TooManyFilesError
@@ -39,16 +39,37 @@ func PrepareDataset(client *http.Client, APIServer string, user map[string]strin
 		}
 		return fullFileArray, err
 	}
-	log.Println("File list collected.")
-	log.Printf("The dataset contains %v files with a total size of %v bytes.\n", numFiles, totalSize)
-
-	UpdateAndLogMetaData(client, APIServer, user, originalMap, metaDataMap, startTime, endTime, owner, tapecopies)
 	return fullFileArray, nil
 }
 
-// UpdateAndLogMetaData updates the dataset's metadata fields from the
+// prepareDataset scans a dataset's local files via datasetIngestor.GetValidatedLocalFileList and,
+// if the dataset survives the empty/too-many-files checks, updates and logs its metadata.
+//
+// The returned error follows the same errors.As pattern as ResolveCentralAvailability:
+// *datasetIngestor.EmptyDatasetError or *datasetIngestor.TooManyFilesError just mean this dataset
+// must be skipped (not fatal, no os.Exit); anything else is a hard failure gathering the local
+// file list. emptyDatasets/tooLargeDatasets are incremented to match whichever of those two
+// errors is returned.
+func prepareDataset(client *http.Client, APIServer string, user map[string]string,
+	originalMap map[string]string, metaDataMap map[string]interface{}, tapecopies int,
+	datasetSourceFolder string, datasetFileListTxt string,
+	symlinkCallback func(symlinkPath string, sourceFolder string) (bool, error),
+	filenameCheckCallback func(filepath string) bool) (fullFileArray []datasetIngestor.Datafile, err error) {
+	fullFileArray, startTime, endTime, owner, numFiles, totalSize, err :=
+		datasetIngestor.GetValidatedLocalFileList(datasetSourceFolder, datasetFileListTxt, symlinkCallback, filenameCheckCallback)
+	if err != nil {
+		return fullFileArray, err
+	}
+	log.Println("File list collected.")
+	log.Printf("The dataset contains %v files with a total size of %v bytes.\n", numFiles, totalSize)
+
+	updateAndLogMetaData(client, APIServer, user, originalMap, metaDataMap, startTime, endTime, owner, tapecopies)
+	return fullFileArray, nil
+}
+
+// updateAndLogMetaData updates the dataset's metadata fields from the
 // scanned file list and logs the resulting metadata object.
-func UpdateAndLogMetaData(client *http.Client, APIServer string, user map[string]string,
+func updateAndLogMetaData(client *http.Client, APIServer string, user map[string]string,
 	originalMap map[string]string, metaDataMap map[string]interface{}, startTime time.Time, endTime time.Time, owner string, tapecopies int) {
 	datasetIngestor.UpdateMetaData(client, APIServer, user, originalMap, metaDataMap, startTime, endTime, owner, tapecopies)
 	pretty, _ := json.MarshalIndent(metaDataMap, "", "    ")
@@ -62,7 +83,7 @@ func PrepareRemoteDataset(client *http.Client, APIServer string, user map[string
 	originalMap map[string]string, metaDataMap map[string]interface{}, tapecopies int) {
 	now := time.Now().UTC()
 	owner := metaDataMap["owner"].(string)
-	UpdateAndLogMetaData(client, APIServer, user, originalMap, metaDataMap, now, now, owner, tapecopies)
+	updateAndLogMetaData(client, APIServer, user, originalMap, metaDataMap, now, now, owner, tapecopies)
 }
 
 // DetermineDatasetLifecycle computes the datasetlifecycle fields for a dataset about to be ingested.
@@ -120,10 +141,13 @@ func (w *NotCentrallyAvailableWarning) Error() string {
 // *NotCentrallyAvailableWarning - not a failure, just something the caller should report. It
 // returns ErrCopyRequiresPersonalAccount if no personal account (access group) is available, and
 // ErrIngestAborted if the user declines to continue.
-func ResolveCentralAvailability(username string, rsyncServer string, datasetSourceFolder string, sshOutput io.Writer,
+func ResolveCentralAvailability(username string, rsyncServer string, datasetSourceFolder string,
 	currentCopyFlag bool, accessGroups []string, noninteractive bool, confirmContinue func() bool) (copyFlag bool, err error) {
+	if len(accessGroups) == 0 {
+		return false, ErrCopyRequiresPersonalAccount
+	}
 	log.Println("Checking if data is centrally available...")
-	sshErr, otherErr := datasetIngestor.CheckDataCentrallyAvailableSsh(username, rsyncServer, datasetSourceFolder, sshOutput)
+	sshErr, otherErr := datasetIngestor.CheckDataCentrallyAvailableSsh(username, rsyncServer, datasetSourceFolder, os.Stdout)
 	if otherErr != nil {
 		return currentCopyFlag, fmt.Errorf("cannot check if data is centrally available: %w", otherErr)
 	}
@@ -132,9 +156,6 @@ func ResolveCentralAvailability(username string, rsyncServer string, datasetSour
 		return currentCopyFlag, nil
 	}
 
-	if len(accessGroups) == 0 {
-		return false, ErrCopyRequiresPersonalAccount
-	}
 	if !noninteractive && confirmContinue != nil && !confirmContinue() {
 		return false, ErrIngestAborted
 	}

--- a/orchestrator/datasetIngestor.go
+++ b/orchestrator/datasetIngestor.go
@@ -152,7 +152,7 @@ func ResolveCentralAvailability(username string, rsyncServer string, datasetSour
 		return false, ErrCopyRequiresPersonalAccount
 	}
 	log.Println("Checking if data is centrally available...")
-	sshErr, otherErr := datasetIngestor.CheckDataCentrallyAvailableSsh(username, rsyncServer, datasetSourceFolder, os.Stdout)
+	sshErr, otherErr := checkDataCentrallyAvailableSsh(username, rsyncServer, datasetSourceFolder, os.Stdout)
 	if otherErr != nil {
 		return currentCopyFlag, fmt.Errorf("cannot check if data is centrally available: %w", otherErr)
 	}

--- a/orchestrator/datasetIngestor.go
+++ b/orchestrator/datasetIngestor.go
@@ -55,6 +55,43 @@ func UpdateAndLogMetaData(client *http.Client, APIServer string, user map[string
 	log.Printf("Updated metadata object:\n%s\n", pretty)
 }
 
+// PrepareRemoteDataset updates and logs metadata for a dataset whose files are accessed remotely and
+// therefore can't be scanned locally: startTime/endTime default to now (there is no file list to derive
+// them from) and owner is read directly from metaDataMap's "owner" field.
+func PrepareRemoteDataset(client *http.Client, APIServer string, user map[string]string,
+	originalMap map[string]string, metaDataMap map[string]interface{}, tapecopies int) {
+	now := time.Now().UTC()
+	owner := metaDataMap["owner"].(string)
+	UpdateAndLogMetaData(client, APIServer, user, originalMap, metaDataMap, now, now, owner, tapecopies)
+}
+
+// DetermineDatasetLifecycle computes the datasetlifecycle fields for a dataset about to be ingested.
+//
+// copyFlag means the files still need to be copied, so the dataset isn't archivable yet.
+//
+// remoteFilesFlag means the files are accessed remotely: their origin datablocks aren't registered yet,
+// so metaArchivable (the value to store in the dataset's metadata) is forced to false. archivable (the
+// value the CLI itself should use to decide whether to queue an archive job) is unaffected by
+// remoteFilesFlag: the job is still queued since, unlike the copyFlag case, no further CLI-driven step
+// will flip it to archivable later.
+func DetermineDatasetLifecycle(copyFlag bool, remoteFilesFlag bool) (archivable bool, metaArchivable bool, isOnCentralDisk bool, archiveStatusMessage string) {
+	if copyFlag {
+		archivable = false
+		isOnCentralDisk = false
+		archiveStatusMessage = "filesNotYetAvailable"
+	} else {
+		archivable = true
+		isOnCentralDisk = true
+		archiveStatusMessage = "datasetCreated"
+	}
+	metaArchivable = archivable
+	if remoteFilesFlag {
+		metaArchivable = false
+		archiveStatusMessage = "origDatablocksNotYetAvailable"
+	}
+	return archivable, metaArchivable, isOnCentralDisk, archiveStatusMessage
+}
+
 // ErrCopyRequiresPersonalAccount is returned when the data is not centrally
 // available (and therefore needs to be copied) but no access group was
 // provided, i.e. a beamline account is used instead of a personal one.

--- a/orchestrator/datasetIngestor.go
+++ b/orchestrator/datasetIngestor.go
@@ -1,0 +1,105 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
+)
+
+// PrepareDataset scans a dataset's local files via datasetIngestor.GetValidatedLocalFileList and,
+// if the dataset survives the empty/too-many-files checks, updates and logs its metadata.
+//
+// The returned error follows the same errors.As pattern as ResolveCentralAvailability:
+// *datasetIngestor.EmptyDatasetError or *datasetIngestor.TooManyFilesError just mean this dataset
+// must be skipped (not fatal, no os.Exit); anything else is a hard failure gathering the local
+// file list. emptyDatasets/tooLargeDatasets are incremented to match whichever of those two
+// errors is returned.
+func PrepareDataset(client *http.Client, APIServer string, user map[string]string,
+	originalMap map[string]string, metaDataMap map[string]interface{}, tapecopies int,
+	datasetSourceFolder string, datasetFileListTxt string,
+	symlinkCallback func(symlinkPath string, sourceFolder string) (bool, error),
+	filenameCheckCallback func(filepath string) bool,
+	emptyDatasets *int, tooLargeDatasets *int) (fullFileArray []datasetIngestor.Datafile, err error) {
+	fullFileArray, startTime, endTime, owner, numFiles, totalSize, err :=
+		datasetIngestor.GetValidatedLocalFileList(datasetSourceFolder, datasetFileListTxt, symlinkCallback, filenameCheckCallback)
+	if err != nil {
+		var emptyDatasetErr *datasetIngestor.EmptyDatasetError
+		var tooManyFilesErr *datasetIngestor.TooManyFilesError
+		switch {
+		case errors.As(err, &emptyDatasetErr):
+			(*emptyDatasets)++
+		case errors.As(err, &tooManyFilesErr):
+			(*tooLargeDatasets)++
+		}
+		return fullFileArray, err
+	}
+	log.Println("File list collected.")
+	log.Printf("The dataset contains %v files with a total size of %v bytes.\n", numFiles, totalSize)
+
+	UpdateAndLogMetaData(client, APIServer, user, originalMap, metaDataMap, startTime, endTime, owner, tapecopies)
+	return fullFileArray, nil
+}
+
+// UpdateAndLogMetaData updates the dataset's metadata fields from the
+// scanned file list and logs the resulting metadata object.
+func UpdateAndLogMetaData(client *http.Client, APIServer string, user map[string]string,
+	originalMap map[string]string, metaDataMap map[string]interface{}, startTime time.Time, endTime time.Time, owner string, tapecopies int) {
+	datasetIngestor.UpdateMetaData(client, APIServer, user, originalMap, metaDataMap, startTime, endTime, owner, tapecopies)
+	pretty, _ := json.MarshalIndent(metaDataMap, "", "    ")
+	log.Printf("Updated metadata object:\n%s\n", pretty)
+}
+
+// ErrCopyRequiresPersonalAccount is returned when the data is not centrally
+// available (and therefore needs to be copied) but no access group was
+// provided, i.e. a beamline account is used instead of a personal one.
+var ErrCopyRequiresPersonalAccount = errors.New("for copying, you must use a personal account. Beamline accounts are not supported.")
+
+// ErrIngestAborted is returned when the caller declines to continue after
+// being told that the data is not centrally available and must be copied.
+var ErrIngestAborted = errors.New("further ingests interrupted because copying is needed, but no copy wanted.")
+
+// NotCentrallyAvailableWarning reports, as a non-fatal warning, that a dataset's sourceFolder is
+// not centrally available and must be copied before it can be archived.
+type NotCentrallyAvailableWarning struct {
+	SourceFolder string
+}
+
+func (w *NotCentrallyAvailableWarning) Error() string {
+	return fmt.Sprintf("The source folder %v is not centrally available.\nThe data must first be copied.\n ", w.SourceFolder)
+}
+
+// ResolveCentralAvailability checks whether the dataset's source folder is available on the
+// central archive server via SSH, and decides the resulting copyFlag (currentCopyFlag is returned
+// unchanged when the data is centrally available).
+//
+// When the data is not centrally available, copying is required: on success (noninteractive, or
+// the user accepted via confirmContinue) it returns copyFlag=true alongside a
+// *NotCentrallyAvailableWarning - not a failure, just something the caller should report. It
+// returns ErrCopyRequiresPersonalAccount if no personal account (access group) is available, and
+// ErrIngestAborted if the user declines to continue.
+func ResolveCentralAvailability(username string, rsyncServer string, datasetSourceFolder string, sshOutput io.Writer,
+	currentCopyFlag bool, accessGroups []string, noninteractive bool, confirmContinue func() bool) (copyFlag bool, err error) {
+	log.Println("Checking if data is centrally available...")
+	sshErr, otherErr := datasetIngestor.CheckDataCentrallyAvailableSsh(username, rsyncServer, datasetSourceFolder, sshOutput)
+	if otherErr != nil {
+		return currentCopyFlag, fmt.Errorf("cannot check if data is centrally available: %w", otherErr)
+	}
+	if sshErr == nil {
+		log.Println("Data is present centrally.")
+		return currentCopyFlag, nil
+	}
+
+	if len(accessGroups) == 0 {
+		return false, ErrCopyRequiresPersonalAccount
+	}
+	if !noninteractive && confirmContinue != nil && !confirmContinue() {
+		return false, ErrIngestAborted
+	}
+	return true, &NotCentrallyAvailableWarning{SourceFolder: datasetSourceFolder}
+}

--- a/orchestrator/datasetIngestor.go
+++ b/orchestrator/datasetIngestor.go
@@ -12,6 +12,11 @@ import (
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 )
 
+// The dependencies are assigned to module level vars so they can be swapped by mocks in tests
+var getValidatedLocalFileListFunc = datasetIngestor.GetValidatedLocalFileList
+var updateMetadataFunc = datasetIngestor.UpdateMetaData
+var checkDataCentrallyAvailableSsh = datasetIngestor.CheckDataCentrallyAvailableSsh
+
 // PrepareDataset scans a dataset's local files via datasetIngestor.GetValidatedLocalFileList and,
 // if the dataset survives the empty/too-many-files checks, updates and logs its metadata.
 //
@@ -56,7 +61,7 @@ func prepareDataset(client *http.Client, APIServer string, user map[string]strin
 	symlinkCallback func(symlinkPath string, sourceFolder string) (bool, error),
 	filenameCheckCallback func(filepath string) bool) (fullFileArray []datasetIngestor.Datafile, err error) {
 	fullFileArray, startTime, endTime, owner, numFiles, totalSize, err :=
-		datasetIngestor.GetValidatedLocalFileList(datasetSourceFolder, datasetFileListTxt, symlinkCallback, filenameCheckCallback)
+		getValidatedLocalFileListFunc(datasetSourceFolder, datasetFileListTxt, symlinkCallback, filenameCheckCallback)
 	if err != nil {
 		return fullFileArray, err
 	}
@@ -71,7 +76,7 @@ func prepareDataset(client *http.Client, APIServer string, user map[string]strin
 // scanned file list and logs the resulting metadata object.
 func updateAndLogMetaData(client *http.Client, APIServer string, user map[string]string,
 	originalMap map[string]string, metaDataMap map[string]interface{}, startTime time.Time, endTime time.Time, owner string, tapecopies int) {
-	datasetIngestor.UpdateMetaData(client, APIServer, user, originalMap, metaDataMap, startTime, endTime, owner, tapecopies)
+	updateMetadataFunc(client, APIServer, user, originalMap, metaDataMap, startTime, endTime, owner, tapecopies)
 	pretty, _ := json.MarshalIndent(metaDataMap, "", "    ")
 	log.Printf("Updated metadata object:\n%s\n", pretty)
 }

--- a/orchestrator/datasetIngestor_test.go
+++ b/orchestrator/datasetIngestor_test.go
@@ -42,7 +42,7 @@ func TestPrepareDataset_EmptyDataset(t *testing.T) {
 	folder := newTestDatasetFolder(t, nil)
 	var emptyDatasets, tooLargeDatasets int
 
-	_, err := PrepareDataset(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
+	_, err := PrepareDatasetAndUpdateCounts(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
 		map[string]string{}, map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}, 1,
 		folder, "", nil, nil, &emptyDatasets, &tooLargeDatasets)
 
@@ -69,7 +69,7 @@ func TestPrepareDataset_NormalDatasetUpdatesMetadata(t *testing.T) {
 	metaDataMap := map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}
 	var emptyDatasets, tooLargeDatasets int
 
-	fullFileArray, err := PrepareDataset(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
+	fullFileArray, err := PrepareDatasetAndUpdateCounts(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
 		map[string]string{}, metaDataMap, 1, folder, "", nil, nil, &emptyDatasets, &tooLargeDatasets)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -111,7 +111,7 @@ func TestPrepareDataset_TooManyFiles(t *testing.T) {
 	}
 	var emptyDatasets, tooLargeDatasets int
 
-	_, err := PrepareDataset(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
+	_, err := PrepareDatasetAndUpdateCounts(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
 		map[string]string{}, map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}, 1,
 		folder, listingPath, nil, nil, &emptyDatasets, &tooLargeDatasets)
 
@@ -130,7 +130,7 @@ func TestPrepareDataset_TooManyFiles(t *testing.T) {
 func TestPrepareDataset_GetLocalFileListError(t *testing.T) {
 	var emptyDatasets, tooLargeDatasets int
 
-	_, err := PrepareDataset(http.DefaultClient, "", map[string]string{}, map[string]string{}, map[string]interface{}{}, 1,
+	_, err := PrepareDatasetAndUpdateCounts(http.DefaultClient, "", map[string]string{}, map[string]string{}, map[string]interface{}{}, 1,
 		filepath.Join(os.TempDir(), "does-not-exist-prepareDataset"), "", nil, nil, &emptyDatasets, &tooLargeDatasets)
 	if err == nil {
 		t.Fatal("expected an error for a nonexistent source folder, got nil")
@@ -141,32 +141,6 @@ func TestPrepareDataset_GetLocalFileListError(t *testing.T) {
 	}
 	if emptyDatasets != 0 || tooLargeDatasets != 0 {
 		t.Errorf("did not expect any counter to be incremented for a scan failure")
-	}
-}
-
-// --- UpdateAndLogMetaData ---
-
-func TestUpdateAndLogMetaData(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
-	}))
-	defer ts.Close()
-
-	client := ts.Client()
-	user := map[string]string{"accessToken": "testToken"}
-	originalMap := map[string]string{}
-	metaDataMap := map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}
-
-	startTime := time.Now()
-	endTime := startTime.Add(time.Hour)
-	UpdateAndLogMetaData(client, ts.URL, user, originalMap, metaDataMap, startTime, endTime, "testOwner", 1)
-
-	if _, ok := metaDataMap["license"]; !ok {
-		t.Errorf("expected metadata to be updated with a license field")
-	}
-	if metaDataMap["ownerGroup"] != "testOwner" {
-		t.Errorf("expected ownerGroup to be updated to 'testOwner', got %v", metaDataMap["ownerGroup"])
 	}
 }
 
@@ -275,7 +249,7 @@ func withSshMocks(t *testing.T, checkErr error, notFound bool) {
 func TestResolveCentralAvailability_Available(t *testing.T) {
 	withSshMocks(t, nil, false)
 
-	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, false, nil)
+	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -287,7 +261,7 @@ func TestResolveCentralAvailability_Available(t *testing.T) {
 func TestResolveCentralAvailability_Available_PreservesCurrentCopyFlag(t *testing.T) {
 	withSshMocks(t, nil, false)
 
-	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, true, []string{"group1"}, false, nil)
+	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", true, []string{"group1"}, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -299,7 +273,7 @@ func TestResolveCentralAvailability_Available_PreservesCurrentCopyFlag(t *testin
 func TestResolveCentralAvailability_NotAvailable_Noninteractive(t *testing.T) {
 	withSshMocks(t, errors.New("not found"), true)
 
-	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, true, nil)
+	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, true, nil)
 	var warning *NotCentrallyAvailableWarning
 	if !errors.As(err, &warning) {
 		t.Fatalf("expected a *NotCentrallyAvailableWarning, got %v", err)
@@ -312,7 +286,7 @@ func TestResolveCentralAvailability_NotAvailable_Noninteractive(t *testing.T) {
 func TestResolveCentralAvailability_NoAccessGroups(t *testing.T) {
 	withSshMocks(t, errors.New("not found"), true)
 
-	_, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, nil, false, func() bool { return true })
+	_, err := ResolveCentralAvailability("user", "server", "/some/folder", false, nil, false, func() bool { return true })
 	if !errors.Is(err, ErrCopyRequiresPersonalAccount) {
 		t.Fatalf("expected ErrCopyRequiresPersonalAccount, got %v", err)
 	}
@@ -321,7 +295,7 @@ func TestResolveCentralAvailability_NoAccessGroups(t *testing.T) {
 func TestResolveCentralAvailability_UserAborts(t *testing.T) {
 	withSshMocks(t, errors.New("not found"), true)
 
-	_, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, false, func() bool { return false })
+	_, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, false, func() bool { return false })
 	if !errors.Is(err, ErrIngestAborted) {
 		t.Fatalf("expected ErrIngestAborted, got %v", err)
 	}
@@ -330,7 +304,7 @@ func TestResolveCentralAvailability_UserAborts(t *testing.T) {
 func TestResolveCentralAvailability_UserConfirms(t *testing.T) {
 	withSshMocks(t, errors.New("not found"), true)
 
-	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, false, func() bool { return true })
+	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, false, func() bool { return true })
 	var warning *NotCentrallyAvailableWarning
 	if !errors.As(err, &warning) {
 		t.Fatalf("expected a *NotCentrallyAvailableWarning, got %v", err)
@@ -352,7 +326,7 @@ func TestResolveCentralAvailability_OtherError(t *testing.T) {
 		return nil, errors.New("connection refused")
 	}
 
-	_, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, false, nil)
+	_, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, false, nil)
 	var warning *NotCentrallyAvailableWarning
 	if err == nil || errors.As(err, &warning) {
 		t.Fatalf("expected a plain error, got %v", err)

--- a/orchestrator/datasetIngestor_test.go
+++ b/orchestrator/datasetIngestor_test.go
@@ -5,142 +5,115 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 )
 
-func newTestDatasetFolder(t *testing.T, files map[string]string) string {
-	t.Helper()
-	tempDir, err := os.MkdirTemp("", "prepareDataset")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(tempDir) })
-
-	for name, content := range files {
-		if err := os.WriteFile(filepath.Join(tempDir, name), []byte(content), 0644); err != nil {
-			t.Fatalf("Failed to create test file %s: %s", name, err)
-		}
-	}
-	return tempDir
-}
-
 // --- PrepareDataset ---
 
-func TestPrepareDataset_EmptyDataset(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
-	}))
-	defer ts.Close()
+func TestPrepareDataset(t *testing.T) {
+	tests := []struct {
+		name              string
+		fileListErr       error
+		checkErr          func(t *testing.T, err error)
+		wantEmptyDatasets int
+		wantTooLarge      int
+	}{
+		{
+			name: "success updates metadata and returns the file list",
+			checkErr: func(t *testing.T, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name:        "empty dataset increments emptyDatasets",
+			fileListErr: &datasetIngestor.EmptyDatasetError{SourceFolder: "/some/folder"},
+			checkErr: func(t *testing.T, err error) {
+				var emptyErr *datasetIngestor.EmptyDatasetError
+				if !errors.As(err, &emptyErr) {
+					t.Fatalf("expected *EmptyDatasetError, got %v", err)
+				}
+			},
+			wantEmptyDatasets: 1,
+		},
+		{
+			name:        "too many files increments tooLargeDatasets",
+			fileListErr: &datasetIngestor.TooManyFilesError{SourceFolder: "/some/folder", NumFiles: 500000, MaxFiles: 400000},
+			checkErr: func(t *testing.T, err error) {
+				var tooManyErr *datasetIngestor.TooManyFilesError
+				if !errors.As(err, &tooManyErr) {
+					t.Fatalf("expected *TooManyFilesError, got %v", err)
+				}
+			},
+			wantTooLarge: 1,
+		},
+		{
+			name:        "other error is not categorized as empty or too-large",
+			fileListErr: errors.New("something else went wrong"),
+			checkErr: func(t *testing.T, err error) {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				var emptyErr *datasetIngestor.EmptyDatasetError
+				var tooManyErr *datasetIngestor.TooManyFilesError
+				if errors.As(err, &emptyErr) || errors.As(err, &tooManyErr) {
+					t.Fatalf("did not expect a categorized error, got %v (%T)", err, err)
+				}
+			},
+		},
+	}
 
-	folder := newTestDatasetFolder(t, nil)
-	var emptyDatasets, tooLargeDatasets int
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldList := getValidatedLocalFileListFunc
+			oldUpdate := updateMetadataFunc
+			t.Cleanup(func() {
+				getValidatedLocalFileListFunc = oldList
+				updateMetadataFunc = oldUpdate
+			})
 
-	_, err := PrepareDatasetAndUpdateCounts(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
-		map[string]string{}, map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}, 1,
-		folder, "", nil, nil, &emptyDatasets, &tooLargeDatasets)
+			wantFiles := []datasetIngestor.Datafile{{Path: "a"}}
+			getValidatedLocalFileListFunc = func(sourceFolder string, filelistingPath string,
+				symlinkCallback func(symlinkPath string, sourceFolder string) (bool, error),
+				filenameFilterCallback func(filepath string) bool,
+			) ([]datasetIngestor.Datafile, time.Time, time.Time, string, int64, int64, error) {
+				if tt.fileListErr != nil {
+					return nil, time.Time{}, time.Time{}, "", 0, 0, tt.fileListErr
+				}
+				return wantFiles, time.Now(), time.Now(), "abc", 1, 10, nil
+			}
 
-	var emptyErr *datasetIngestor.EmptyDatasetError
-	if !errors.As(err, &emptyErr) {
-		t.Fatalf("expected *EmptyDatasetError, got %v", err)
-	}
-	if emptyDatasets != 1 {
-		t.Errorf("emptyDatasets = %d, want 1", emptyDatasets)
-	}
-	if tooLargeDatasets != 0 {
-		t.Errorf("tooLargeDatasets = %d, want 0", tooLargeDatasets)
-	}
-}
+			updateMetadataCalled := false
+			updateMetadataFunc = func(client *http.Client, APIServer string, user map[string]string,
+				originalMap map[string]string, metaDataMap map[string]interface{}, startTime time.Time, endTime time.Time, owner string, tapecopies int) {
+				updateMetadataCalled = true
+			}
 
-func TestPrepareDataset_NormalDatasetUpdatesMetadata(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
-	}))
-	defer ts.Close()
+			var emptyDatasets, tooLargeDatasets int
+			fullFileArray, err := PrepareDatasetAndUpdateCounts(nil, "", map[string]string{"accessToken": "testToken"},
+				map[string]string{}, map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}, 1,
+				"/some/folder", "", nil, nil, &emptyDatasets, &tooLargeDatasets)
 
-	folder := newTestDatasetFolder(t, map[string]string{"a": "hello"})
-	metaDataMap := map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}
-	var emptyDatasets, tooLargeDatasets int
+			tt.checkErr(t, err)
 
-	fullFileArray, err := PrepareDatasetAndUpdateCounts(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
-		map[string]string{}, metaDataMap, 1, folder, "", nil, nil, &emptyDatasets, &tooLargeDatasets)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(fullFileArray) != 1 {
-		t.Errorf("expected 1 file, got %d", len(fullFileArray))
-	}
-	if _, ok := metaDataMap["license"]; !ok {
-		t.Errorf("expected metadata to be updated with a license field")
-	}
-	if metaDataMap["ownerGroup"] == datasetIngestor.DUMMY_OWNER {
-		t.Errorf("expected ownerGroup to no longer be the dummy value")
-	}
-	if emptyDatasets != 0 || tooLargeDatasets != 0 {
-		t.Errorf("did not expect any dataset to be skipped")
-	}
-}
-
-func TestPrepareDataset_TooManyFiles(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
-	}))
-	defer ts.Close()
-
-	folder := newTestDatasetFolder(t, map[string]string{"a": "hello"})
-
-	// GetLocalFileList walks each line of the file listing independently, so listing the same
-	// real file more times than TOTAL_MAXFILES allows drives numFiles past the limit without
-	// creating hundreds of thousands of files on disk (which is prohibitively slow, especially
-	// on Windows with real-time antivirus scanning).
-	var listing strings.Builder
-	for i := 0; i < datasetIngestor.TOTAL_MAXFILES+1; i++ {
-		listing.WriteString("a\n")
-	}
-	listingPath := filepath.Join(folder, "filelisting.txt")
-	if err := os.WriteFile(listingPath, []byte(listing.String()), 0644); err != nil {
-		t.Fatalf("failed to write file listing: %s", err)
-	}
-	var emptyDatasets, tooLargeDatasets int
-
-	_, err := PrepareDatasetAndUpdateCounts(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
-		map[string]string{}, map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}, 1,
-		folder, listingPath, nil, nil, &emptyDatasets, &tooLargeDatasets)
-
-	var tooManyErr *datasetIngestor.TooManyFilesError
-	if !errors.As(err, &tooManyErr) {
-		t.Fatalf("expected *TooManyFilesError, got %v", err)
-	}
-	if tooLargeDatasets != 1 {
-		t.Errorf("tooLargeDatasets = %d, want 1", tooLargeDatasets)
-	}
-	if emptyDatasets != 0 {
-		t.Errorf("emptyDatasets = %d, want 0", emptyDatasets)
-	}
-}
-
-func TestPrepareDataset_GetLocalFileListError(t *testing.T) {
-	var emptyDatasets, tooLargeDatasets int
-
-	_, err := PrepareDatasetAndUpdateCounts(http.DefaultClient, "", map[string]string{}, map[string]string{}, map[string]interface{}{}, 1,
-		filepath.Join(os.TempDir(), "does-not-exist-prepareDataset"), "", nil, nil, &emptyDatasets, &tooLargeDatasets)
-	if err == nil {
-		t.Fatal("expected an error for a nonexistent source folder, got nil")
-	}
-	var emptyErr *datasetIngestor.EmptyDatasetError
-	if errors.As(err, &emptyErr) {
-		t.Errorf("did not expect an *EmptyDatasetError for a scan failure, got %v", err)
-	}
-	if emptyDatasets != 0 || tooLargeDatasets != 0 {
-		t.Errorf("did not expect any counter to be incremented for a scan failure")
+			wantCalled := tt.fileListErr == nil
+			if updateMetadataCalled != wantCalled {
+				t.Errorf("updateMetadataFunc called = %v, want %v", updateMetadataCalled, wantCalled)
+			}
+			if wantCalled && len(fullFileArray) != len(wantFiles) {
+				t.Errorf("expected %d file(s), got %d", len(wantFiles), len(fullFileArray))
+			}
+			if emptyDatasets != tt.wantEmptyDatasets {
+				t.Errorf("emptyDatasets = %d, want %d", emptyDatasets, tt.wantEmptyDatasets)
+			}
+			if tooLargeDatasets != tt.wantTooLarge {
+				t.Errorf("tooLargeDatasets = %d, want %d", tooLargeDatasets, tt.wantTooLarge)
+			}
+		})
 	}
 }
 

--- a/orchestrator/datasetIngestor_test.go
+++ b/orchestrator/datasetIngestor_test.go
@@ -195,32 +195,17 @@ func TestDetermineDatasetLifecycle(t *testing.T) {
 
 // --- ResolveCentralAvailability ---
 
-func withSshMocks(t *testing.T, checkErr error, notFound bool) {
+func withSshMock(t *testing.T, sshErr error, otherErr error) {
 	t.Helper()
-	oldGoos := datasetIngestor.Goos
-	oldNewDumbClient := datasetIngestor.NewDumbClientFunc
-	oldCheckRemoteDirectory := datasetIngestor.CheckRemoteDirectoryFunc
-	oldIsNotFound := datasetIngestor.IsRemoteDirectoryNotFound
-	t.Cleanup(func() {
-		datasetIngestor.Goos = oldGoos
-		datasetIngestor.NewDumbClientFunc = oldNewDumbClient
-		datasetIngestor.CheckRemoteDirectoryFunc = oldCheckRemoteDirectory
-		datasetIngestor.IsRemoteDirectoryNotFound = oldIsNotFound
-	})
-	// Force the pure-Go SSH client path (normally Windows-only) so the mocks below take effect
-	// regardless of the OS running the tests.
-	datasetIngestor.Goos = "windows"
-	datasetIngestor.NewDumbClientFunc = func(username, password, server string) (*datasetIngestor.Client, error) {
-		return &datasetIngestor.Client{}, nil
+	old := checkDataCentrallyAvailableSsh
+	t.Cleanup(func() { checkDataCentrallyAvailableSsh = old })
+	checkDataCentrallyAvailableSsh = func(username, ARCHIVEServer, sourceFolder string, sshOutput io.Writer) (error, error) {
+		return sshErr, otherErr
 	}
-	datasetIngestor.CheckRemoteDirectoryFunc = func(c *datasetIngestor.Client, sourceFolder string, sshOutput io.Writer) error {
-		return checkErr
-	}
-	datasetIngestor.IsRemoteDirectoryNotFound = func(err error) bool { return notFound }
 }
 
 func TestResolveCentralAvailability_Available(t *testing.T) {
-	withSshMocks(t, nil, false)
+	withSshMock(t, nil, nil)
 
 	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, false, nil)
 	if err != nil {
@@ -232,7 +217,7 @@ func TestResolveCentralAvailability_Available(t *testing.T) {
 }
 
 func TestResolveCentralAvailability_Available_PreservesCurrentCopyFlag(t *testing.T) {
-	withSshMocks(t, nil, false)
+	withSshMock(t, nil, nil)
 
 	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", true, []string{"group1"}, false, nil)
 	if err != nil {
@@ -244,7 +229,7 @@ func TestResolveCentralAvailability_Available_PreservesCurrentCopyFlag(t *testin
 }
 
 func TestResolveCentralAvailability_NotAvailable_Noninteractive(t *testing.T) {
-	withSshMocks(t, errors.New("not found"), true)
+	withSshMock(t, errors.New("not found"), nil)
 
 	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, true, nil)
 	var warning *NotCentrallyAvailableWarning
@@ -257,8 +242,8 @@ func TestResolveCentralAvailability_NotAvailable_Noninteractive(t *testing.T) {
 }
 
 func TestResolveCentralAvailability_NoAccessGroups(t *testing.T) {
-	withSshMocks(t, errors.New("not found"), true)
-
+	// ResolveCentralAvailability returns before ever checking central availability when there's
+	// no access group, so no ssh mock is needed here.
 	_, err := ResolveCentralAvailability("user", "server", "/some/folder", false, nil, false, func() bool { return true })
 	if !errors.Is(err, ErrCopyRequiresPersonalAccount) {
 		t.Fatalf("expected ErrCopyRequiresPersonalAccount, got %v", err)
@@ -266,7 +251,7 @@ func TestResolveCentralAvailability_NoAccessGroups(t *testing.T) {
 }
 
 func TestResolveCentralAvailability_UserAborts(t *testing.T) {
-	withSshMocks(t, errors.New("not found"), true)
+	withSshMock(t, errors.New("not found"), nil)
 
 	_, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, false, func() bool { return false })
 	if !errors.Is(err, ErrIngestAborted) {
@@ -275,7 +260,7 @@ func TestResolveCentralAvailability_UserAborts(t *testing.T) {
 }
 
 func TestResolveCentralAvailability_UserConfirms(t *testing.T) {
-	withSshMocks(t, errors.New("not found"), true)
+	withSshMock(t, errors.New("not found"), nil)
 
 	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, false, func() bool { return true })
 	var warning *NotCentrallyAvailableWarning
@@ -288,16 +273,7 @@ func TestResolveCentralAvailability_UserConfirms(t *testing.T) {
 }
 
 func TestResolveCentralAvailability_OtherError(t *testing.T) {
-	oldGoos := datasetIngestor.Goos
-	oldNewDumbClient := datasetIngestor.NewDumbClientFunc
-	t.Cleanup(func() {
-		datasetIngestor.Goos = oldGoos
-		datasetIngestor.NewDumbClientFunc = oldNewDumbClient
-	})
-	datasetIngestor.Goos = "windows"
-	datasetIngestor.NewDumbClientFunc = func(username, password, server string) (*datasetIngestor.Client, error) {
-		return nil, errors.New("connection refused")
-	}
+	withSshMock(t, nil, errors.New("connection refused"))
 
 	_, err := ResolveCentralAvailability("user", "server", "/some/folder", false, []string{"group1"}, false, nil)
 	var warning *NotCentrallyAvailableWarning

--- a/orchestrator/datasetIngestor_test.go
+++ b/orchestrator/datasetIngestor_test.go
@@ -1,0 +1,284 @@
+package orchestrator
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
+)
+
+func newTestDatasetFolder(t *testing.T, files map[string]string) string {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "prepareDataset")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(tempDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create test file %s: %s", name, err)
+		}
+	}
+	return tempDir
+}
+
+// --- PrepareDataset ---
+
+func TestPrepareDataset_EmptyDataset(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer ts.Close()
+
+	folder := newTestDatasetFolder(t, nil)
+	var emptyDatasets, tooLargeDatasets int
+
+	_, err := PrepareDataset(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
+		map[string]string{}, map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}, 1,
+		folder, "", nil, nil, &emptyDatasets, &tooLargeDatasets)
+
+	var emptyErr *datasetIngestor.EmptyDatasetError
+	if !errors.As(err, &emptyErr) {
+		t.Fatalf("expected *EmptyDatasetError, got %v", err)
+	}
+	if emptyDatasets != 1 {
+		t.Errorf("emptyDatasets = %d, want 1", emptyDatasets)
+	}
+	if tooLargeDatasets != 0 {
+		t.Errorf("tooLargeDatasets = %d, want 0", tooLargeDatasets)
+	}
+}
+
+func TestPrepareDataset_NormalDatasetUpdatesMetadata(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer ts.Close()
+
+	folder := newTestDatasetFolder(t, map[string]string{"a": "hello"})
+	metaDataMap := map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}
+	var emptyDatasets, tooLargeDatasets int
+
+	fullFileArray, err := PrepareDataset(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
+		map[string]string{}, metaDataMap, 1, folder, "", nil, nil, &emptyDatasets, &tooLargeDatasets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fullFileArray) != 1 {
+		t.Errorf("expected 1 file, got %d", len(fullFileArray))
+	}
+	if _, ok := metaDataMap["license"]; !ok {
+		t.Errorf("expected metadata to be updated with a license field")
+	}
+	if metaDataMap["ownerGroup"] == datasetIngestor.DUMMY_OWNER {
+		t.Errorf("expected ownerGroup to no longer be the dummy value")
+	}
+	if emptyDatasets != 0 || tooLargeDatasets != 0 {
+		t.Errorf("did not expect any dataset to be skipped")
+	}
+}
+
+func TestPrepareDataset_TooManyFiles(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer ts.Close()
+
+	folder := newTestDatasetFolder(t, map[string]string{"a": "hello"})
+
+	// GetLocalFileList walks each line of the file listing independently, so listing the same
+	// real file more times than TOTAL_MAXFILES allows drives numFiles past the limit without
+	// creating hundreds of thousands of files on disk (which is prohibitively slow, especially
+	// on Windows with real-time antivirus scanning).
+	var listing strings.Builder
+	for i := 0; i < datasetIngestor.TOTAL_MAXFILES+1; i++ {
+		listing.WriteString("a\n")
+	}
+	listingPath := filepath.Join(folder, "filelisting.txt")
+	if err := os.WriteFile(listingPath, []byte(listing.String()), 0644); err != nil {
+		t.Fatalf("failed to write file listing: %s", err)
+	}
+	var emptyDatasets, tooLargeDatasets int
+
+	_, err := PrepareDataset(ts.Client(), ts.URL, map[string]string{"accessToken": "testToken"},
+		map[string]string{}, map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}, 1,
+		folder, listingPath, nil, nil, &emptyDatasets, &tooLargeDatasets)
+
+	var tooManyErr *datasetIngestor.TooManyFilesError
+	if !errors.As(err, &tooManyErr) {
+		t.Fatalf("expected *TooManyFilesError, got %v", err)
+	}
+	if tooLargeDatasets != 1 {
+		t.Errorf("tooLargeDatasets = %d, want 1", tooLargeDatasets)
+	}
+	if emptyDatasets != 0 {
+		t.Errorf("emptyDatasets = %d, want 0", emptyDatasets)
+	}
+}
+
+func TestPrepareDataset_GetLocalFileListError(t *testing.T) {
+	var emptyDatasets, tooLargeDatasets int
+
+	_, err := PrepareDataset(http.DefaultClient, "", map[string]string{}, map[string]string{}, map[string]interface{}{}, 1,
+		filepath.Join(os.TempDir(), "does-not-exist-prepareDataset"), "", nil, nil, &emptyDatasets, &tooLargeDatasets)
+	if err == nil {
+		t.Fatal("expected an error for a nonexistent source folder, got nil")
+	}
+	var emptyErr *datasetIngestor.EmptyDatasetError
+	if errors.As(err, &emptyErr) {
+		t.Errorf("did not expect an *EmptyDatasetError for a scan failure, got %v", err)
+	}
+	if emptyDatasets != 0 || tooLargeDatasets != 0 {
+		t.Errorf("did not expect any counter to be incremented for a scan failure")
+	}
+}
+
+// --- UpdateAndLogMetaData ---
+
+func TestUpdateAndLogMetaData(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer ts.Close()
+
+	client := ts.Client()
+	user := map[string]string{"accessToken": "testToken"}
+	originalMap := map[string]string{}
+	metaDataMap := map[string]interface{}{"ownerGroup": datasetIngestor.DUMMY_OWNER}
+
+	startTime := time.Now()
+	endTime := startTime.Add(time.Hour)
+	UpdateAndLogMetaData(client, ts.URL, user, originalMap, metaDataMap, startTime, endTime, "testOwner", 1)
+
+	if _, ok := metaDataMap["license"]; !ok {
+		t.Errorf("expected metadata to be updated with a license field")
+	}
+	if metaDataMap["ownerGroup"] != "testOwner" {
+		t.Errorf("expected ownerGroup to be updated to 'testOwner', got %v", metaDataMap["ownerGroup"])
+	}
+}
+
+// --- ResolveCentralAvailability ---
+
+func withSshMocks(t *testing.T, checkErr error, notFound bool) {
+	t.Helper()
+	oldGoos := datasetIngestor.Goos
+	oldNewDumbClient := datasetIngestor.NewDumbClientFunc
+	oldCheckRemoteDirectory := datasetIngestor.CheckRemoteDirectoryFunc
+	oldIsNotFound := datasetIngestor.IsRemoteDirectoryNotFound
+	t.Cleanup(func() {
+		datasetIngestor.Goos = oldGoos
+		datasetIngestor.NewDumbClientFunc = oldNewDumbClient
+		datasetIngestor.CheckRemoteDirectoryFunc = oldCheckRemoteDirectory
+		datasetIngestor.IsRemoteDirectoryNotFound = oldIsNotFound
+	})
+	// Force the pure-Go SSH client path (normally Windows-only) so the mocks below take effect
+	// regardless of the OS running the tests.
+	datasetIngestor.Goos = "windows"
+	datasetIngestor.NewDumbClientFunc = func(username, password, server string) (*datasetIngestor.Client, error) {
+		return &datasetIngestor.Client{}, nil
+	}
+	datasetIngestor.CheckRemoteDirectoryFunc = func(c *datasetIngestor.Client, sourceFolder string, sshOutput io.Writer) error {
+		return checkErr
+	}
+	datasetIngestor.IsRemoteDirectoryNotFound = func(err error) bool { return notFound }
+}
+
+func TestResolveCentralAvailability_Available(t *testing.T) {
+	withSshMocks(t, nil, false)
+
+	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if copyFlag {
+		t.Errorf("did not expect copyFlag to be set when data is centrally available")
+	}
+}
+
+func TestResolveCentralAvailability_Available_PreservesCurrentCopyFlag(t *testing.T) {
+	withSshMocks(t, nil, false)
+
+	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, true, []string{"group1"}, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !copyFlag {
+		t.Errorf("expected copyFlag to remain true when data is centrally available")
+	}
+}
+
+func TestResolveCentralAvailability_NotAvailable_Noninteractive(t *testing.T) {
+	withSshMocks(t, errors.New("not found"), true)
+
+	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, true, nil)
+	var warning *NotCentrallyAvailableWarning
+	if !errors.As(err, &warning) {
+		t.Fatalf("expected a *NotCentrallyAvailableWarning, got %v", err)
+	}
+	if !copyFlag {
+		t.Errorf("expected copyFlag to be true when data is not centrally available")
+	}
+}
+
+func TestResolveCentralAvailability_NoAccessGroups(t *testing.T) {
+	withSshMocks(t, errors.New("not found"), true)
+
+	_, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, nil, false, func() bool { return true })
+	if !errors.Is(err, ErrCopyRequiresPersonalAccount) {
+		t.Fatalf("expected ErrCopyRequiresPersonalAccount, got %v", err)
+	}
+}
+
+func TestResolveCentralAvailability_UserAborts(t *testing.T) {
+	withSshMocks(t, errors.New("not found"), true)
+
+	_, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, false, func() bool { return false })
+	if !errors.Is(err, ErrIngestAborted) {
+		t.Fatalf("expected ErrIngestAborted, got %v", err)
+	}
+}
+
+func TestResolveCentralAvailability_UserConfirms(t *testing.T) {
+	withSshMocks(t, errors.New("not found"), true)
+
+	copyFlag, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, false, func() bool { return true })
+	var warning *NotCentrallyAvailableWarning
+	if !errors.As(err, &warning) {
+		t.Fatalf("expected a *NotCentrallyAvailableWarning, got %v", err)
+	}
+	if !copyFlag {
+		t.Errorf("expected copyFlag to be true")
+	}
+}
+
+func TestResolveCentralAvailability_OtherError(t *testing.T) {
+	oldGoos := datasetIngestor.Goos
+	oldNewDumbClient := datasetIngestor.NewDumbClientFunc
+	t.Cleanup(func() {
+		datasetIngestor.Goos = oldGoos
+		datasetIngestor.NewDumbClientFunc = oldNewDumbClient
+	})
+	datasetIngestor.Goos = "windows"
+	datasetIngestor.NewDumbClientFunc = func(username, password, server string) (*datasetIngestor.Client, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	_, err := ResolveCentralAvailability("user", "server", "/some/folder", nil, false, []string{"group1"}, false, nil)
+	var warning *NotCentrallyAvailableWarning
+	if err == nil || errors.As(err, &warning) {
+		t.Fatalf("expected a plain error, got %v", err)
+	}
+}

--- a/orchestrator/datasetIngestor_test.go
+++ b/orchestrator/datasetIngestor_test.go
@@ -170,6 +170,82 @@ func TestUpdateAndLogMetaData(t *testing.T) {
 	}
 }
 
+// --- PrepareRemoteDataset ---
+
+func TestPrepareRemoteDataset(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer ts.Close()
+
+	client := ts.Client()
+	user := map[string]string{"accessToken": "testToken"}
+	originalMap := map[string]string{}
+	metaDataMap := map[string]interface{}{
+		"ownerGroup":   datasetIngestor.DUMMY_OWNER,
+		"owner":        "testOwner",
+		"creationTime": datasetIngestor.DUMMY_TIME,
+	}
+
+	before := time.Now()
+	PrepareRemoteDataset(client, ts.URL, user, originalMap, metaDataMap, 1)
+	after := time.Now()
+
+	if _, ok := metaDataMap["license"]; !ok {
+		t.Errorf("expected metadata to be updated with a license field")
+	}
+	if metaDataMap["ownerGroup"] != "testOwner" {
+		t.Errorf("expected ownerGroup to be updated to 'testOwner', got %v", metaDataMap["ownerGroup"])
+	}
+	creationTime, ok := metaDataMap["creationTime"].(time.Time)
+	if !ok {
+		t.Fatalf("expected creationTime to be set to a time.Time, got %v", metaDataMap["creationTime"])
+	}
+	if creationTime.Before(before) || creationTime.After(after) {
+		t.Errorf("expected creationTime to be set to roughly now, got %v (want between %v and %v)", creationTime, before, after)
+	}
+}
+
+// --- DetermineDatasetLifecycle ---
+
+func TestDetermineDatasetLifecycle(t *testing.T) {
+	tests := []struct {
+		name                     string
+		copyFlag                 bool
+		remoteFilesFlag          bool
+		wantArchivable           bool
+		wantMetaArchivable       bool
+		wantIsOnCentralDisk      bool
+		wantArchiveStatusMessage string
+	}{
+		{"local, no copy needed", false, false, true, true, true, "datasetCreated"},
+		{"local, copy needed", true, false, false, false, false, "filesNotYetAvailable"},
+		// remoteFilesFlag forces the metadata's archivable field to false (the origin datablocks
+		// aren't registered yet), but the CLI still queues an archive job (archivable stays true)
+		// since there's no later CLI-driven step, unlike the copyFlag case, that would flip it.
+		{"remote files", false, true, true, false, true, "origDatablocksNotYetAvailable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			archivable, metaArchivable, isOnCentralDisk, archiveStatusMessage := DetermineDatasetLifecycle(tt.copyFlag, tt.remoteFilesFlag)
+			if archivable != tt.wantArchivable {
+				t.Errorf("archivable = %v, want %v", archivable, tt.wantArchivable)
+			}
+			if metaArchivable != tt.wantMetaArchivable {
+				t.Errorf("metaArchivable = %v, want %v", metaArchivable, tt.wantMetaArchivable)
+			}
+			if isOnCentralDisk != tt.wantIsOnCentralDisk {
+				t.Errorf("isOnCentralDisk = %v, want %v", isOnCentralDisk, tt.wantIsOnCentralDisk)
+			}
+			if archiveStatusMessage != tt.wantArchiveStatusMessage {
+				t.Errorf("archiveStatusMessage = %v, want %v", archiveStatusMessage, tt.wantArchiveStatusMessage)
+			}
+		})
+	}
+}
+
 // --- ResolveCentralAvailability ---
 
 func withSshMocks(t *testing.T, checkErr error, notFound bool) {


### PR DESCRIPTION
This PR adds a `remote-files` flag which enables to run the ingestion with files not available where the cli runs. 

It follows the orchestrator folder pattern for testability and it's easier to review when reading one commit at a time