### PR TITLE
fix: revert using go for ssh linux check

### DIFF
--- a/datasetIngestor/checkDataCentrallyAvailableSsh.go
+++ b/datasetIngestor/checkDataCentrallyAvailableSsh.go
@@ -2,12 +2,19 @@ package datasetIngestor
 
 import (
 	"errors"
-	"fmt"
 	"io"
+	"net"
+	"os/exec"
 	"runtime"
 
 	"golang.org/x/crypto/ssh"
 )
+
+// goos is a variable that points to runtime.GOOS, allowing it to be replaced in tests.
+var goos = runtime.GOOS
+
+// execCommand is a variable that points to exec.Command, allowing it to be replaced in tests.
+var execCommand = exec.Command
 
 // newDumbClient is a variable that points to NewDumbClient, allowing it to be replaced in tests.
 var newDumbClient = NewDumbClient
@@ -17,9 +24,19 @@ var checkRemoteDirectory = func(c *Client, sourceFolder string, sshOutput io.Wri
 	return c.CheckRemoteDirectory(sourceFolder, sshOutput)
 }
 
-// isRemoteDirectoryNotFound classifies SSH command errors where remote "test -d"
-// evaluated to false (exit status 1).
-var isRemoteDirectoryNotFound = func(err error) bool {
+// isRemoteDirectoryNotFoundExec classifies native ssh command errors where remote "test -d"
+// evaluated to false (exit status 1), as opposed to a connection/authentication failure or another error.
+var isRemoteDirectoryNotFoundExec = func(err error) bool {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode() == 1
+	}
+	return false
+}
+
+// isRemoteDirectoryNotFoundSsh classifies pure-Go SSH client errors where remote "test -d"
+// evaluated to false (exit status 1), as opposed to a connection/authentication failure or another error.
+var isRemoteDirectoryNotFoundSsh = func(err error) bool {
 	var exitErr *ssh.ExitError
 	if errors.As(err, &exitErr) {
 		return exitErr.ExitStatus() == 1
@@ -27,18 +44,25 @@ var isRemoteDirectoryNotFound = func(err error) bool {
 	return false
 }
 
-// CheckDataCentrallyAvailableSsh checks if a specific directory (sourceFolder) is available on a remote server (ARCHIVEServer)
-// using the provided username for SSH connection. It returns an error if the directory is not available or if there's an issue with the SSH connection.
-// Returned values:
-// - sshErr - the error returned by the ssh command
-// - err - other error that prevents the ssh command from being executed
-func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourceFolder string, sshOutput io.Writer) (sshErr error, otherErr error) {
-	// NOTE why not use crypto/ssh ???
-	// NOTE even if the folder is there, not all files might be there!
+/*
+CheckDataCentrallyAvailableSsh checks if a specific directory (sourceFolder) is available on a
+remote server (ARCHIVEServer) using the provided username for SSH connection.
 
-	// Check the operating system
-	switch os := runtime.GOOS; os {
-	case "linux", "windows", "darwin":
+On Windows, no native ssh/scp binary is guaranteed to be present, so this reuses the same pure-Go
+SSH client (with Kerberos/GSSAPI support) already used for the Windows data-transfer path in
+scp.go. Everywhere else it shells out to the system's ssh binary rather than using that pure-Go
+client, so that whatever authentication the user's environment is already set up for
+(Kerberos/GSSAPI via any credential cache type, ssh-agent, ~/.ssh/config host aliases, etc.) works
+exactly as it would for an interactive ssh command - no additional setup should be required of the
+user.
+
+Returned values:
+  - sshErr - the error returned by the remote directory check
+  - otherErr - other error that prevents the check from being executed
+*/
+func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourceFolder string, sshOutput io.Writer) (sshErr error, otherErr error) {
+	switch goos {
+	case "windows":
 		client, err := newDumbClient(username, "", ARCHIVEServer)
 		if err != nil {
 			return nil, err
@@ -51,11 +75,39 @@ func CheckDataCentrallyAvailableSsh(username string, ARCHIVEServer string, sourc
 		if err == nil {
 			return nil, nil
 		}
-		if isRemoteDirectoryNotFound(err) {
+		if isRemoteDirectoryNotFoundSsh(err) {
 			return err, nil
 		}
 		return nil, err
 	default:
-		return nil, fmt.Errorf("unsupported operating system: %s", os)
+		if _, err := exec.LookPath("ssh"); err != nil {
+			return nil, errors.New("no ssh implementation is available")
+		}
+
+		host, port, err := net.SplitHostPort(ARCHIVEServer)
+		if err != nil {
+			host = ARCHIVEServer
+			port = ""
+		}
+
+		args := []string{"-q"}
+		if port != "" {
+			args = append(args, "-p", port)
+		}
+		// "-q" suppresses all warnings, "-l" specifies the login name on the remote server.
+		args = append(args, "-l", username, host, "test", "-d", sourceFolder)
+
+		cmd := execCommand("ssh", args...)
+		cmd.Stdout = sshOutput
+		cmd.Stderr = sshOutput
+
+		err = cmd.Run()
+		if err == nil {
+			return nil, nil
+		}
+		if isRemoteDirectoryNotFoundExec(err) {
+			return err, nil
+		}
+		return nil, err
 	}
 }

--- a/datasetIngestor/checkDataCentrallyAvailableSsh_test.go
+++ b/datasetIngestor/checkDataCentrallyAvailableSsh_test.go
@@ -2,9 +2,48 @@ package datasetIngestor
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"strconv"
 	"testing"
 )
+
+// execCommandMock replaces execCommand with one that re-execs this test binary (via
+// TestHelperProcess below) instead of actually running ssh, so tests can control the exit code
+// without a real ssh binary or network access.
+type execCommandMock struct {
+	t            *testing.T
+	expectedArgs []string
+	exitStatus   int
+}
+
+func (m *execCommandMock) Command(name string, arg ...string) *exec.Cmd {
+	m.t.Helper()
+	if !reflect.DeepEqual(arg, m.expectedArgs) {
+		m.t.Errorf("unexpected arguments: got %v, want %v", arg, m.expectedArgs)
+	}
+
+	cs := make([]string, 0, 3+len(arg))
+	cs = append(cs, "-test.run=TestHelperProcess", "--", name)
+	cs = append(cs, arg...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", fmt.Sprintf("EXIT_STATUS=%d", m.exitStatus)}
+	return cmd
+}
+
+// TestHelperProcess isn't a real test. It's a helper subprocess used by execCommandMock.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stdout, "output")
+	fmt.Fprint(os.Stderr, "error")
+	exitStatus, _ := strconv.Atoi(os.Getenv("EXIT_STATUS"))
+	os.Exit(exitStatus)
+}
 
 func TestCheckDataCentrallyAvailable(t *testing.T) {
 	tests := []struct {
@@ -12,82 +51,167 @@ func TestCheckDataCentrallyAvailable(t *testing.T) {
 		username      string
 		archiveServer string
 		sourceFolder  string
+		expectedArgs  []string
+		exitStatus    int
+		wantSshErr    bool
+		wantOtherErr  bool
+	}{
+		{
+			name:          "data centrally available",
+			username:      "testuser",
+			archiveServer: "testserver",
+			sourceFolder:  "/test/folder",
+			expectedArgs:  []string{"-q", "-l", "testuser", "testserver", "test", "-d", "/test/folder"},
+			exitStatus:    0,
+		},
+		{
+			name:          "data not available",
+			username:      "testuser",
+			archiveServer: "testserver",
+			sourceFolder:  "/nonexistent/folder",
+			expectedArgs:  []string{"-q", "-l", "testuser", "testserver", "test", "-d", "/nonexistent/folder"},
+			exitStatus:    1,
+			wantSshErr:    true,
+		},
+		{
+			name:          "other ssh failure",
+			username:      "testuser",
+			archiveServer: "testserver",
+			sourceFolder:  "/some/folder",
+			expectedArgs:  []string{"-q", "-l", "testuser", "testserver", "test", "-d", "/some/folder"},
+			exitStatus:    255,
+			wantOtherErr:  true,
+		},
+		{
+			name:          "server with explicit port",
+			username:      "testuser",
+			archiveServer: "testserver:2022",
+			sourceFolder:  "/test/folder",
+			expectedArgs:  []string{"-q", "-p", "2022", "-l", "testuser", "testserver", "test", "-d", "/test/folder"},
+			exitStatus:    0,
+		},
+	}
+
+	oldGoos := goos
+	t.Cleanup(func() { goos = oldGoos })
+	goos = "linux"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldExecCommand := execCommand
+			t.Cleanup(func() { execCommand = oldExecCommand })
+			execCommand = (&execCommandMock{t: t, expectedArgs: tt.expectedArgs, exitStatus: tt.exitStatus}).Command
+
+			sshErr, otherErr := CheckDataCentrallyAvailableSsh(tt.username, tt.archiveServer, tt.sourceFolder, nil)
+			if (sshErr != nil) != tt.wantSshErr {
+				t.Errorf("CheckDataCentrallyAvailableSsh() sshErr = %v, wantSshErr %v", sshErr, tt.wantSshErr)
+			}
+			if (otherErr != nil) != tt.wantOtherErr {
+				t.Errorf("CheckDataCentrallyAvailableSsh() otherErr = %v, wantOtherErr %v", otherErr, tt.wantOtherErr)
+			}
+		})
+	}
+}
+
+func TestCheckDataCentrallyAvailable_NoSshBinary(t *testing.T) {
+	oldGoos := goos
+	t.Cleanup(func() { goos = oldGoos })
+	goos = "linux"
+
+	oldPath := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", oldPath) })
+	os.Setenv("PATH", "")
+
+	sshErr, otherErr := CheckDataCentrallyAvailableSsh("testuser", "testserver", "/test/folder", nil)
+	if sshErr != nil {
+		t.Errorf("expected no sshErr, got %v", sshErr)
+	}
+	if otherErr == nil {
+		t.Fatal("expected an error when ssh is not available, got nil")
+	}
+}
+
+func TestCheckDataCentrallyAvailable_Windows(t *testing.T) {
+	tests := []struct {
+		name          string
 		isNotFoundErr bool
 		wantSshErr    bool
 		wantOtherErr  bool
 		errMsg        string
 	}{
 		{
-			name:          "test data centrally available",
-			username:      "testuser",
-			archiveServer: "testserver",
-			sourceFolder:  "/test/folder",
-			isNotFoundErr: false,
-			wantSshErr:    false,
-			wantOtherErr:  false,
+			name: "data centrally available",
 		},
 		{
-			name:          "test data not available",
-			username:      "testuser",
-			archiveServer: "testserver",
-			sourceFolder:  "/nonexistent/folder",
+			name:          "data not available",
 			isNotFoundErr: true,
 			wantSshErr:    true,
-			wantOtherErr:  false,
 			errMsg:        "exit status 1",
 		},
 		{
-			name:          "test remote check other failure",
-			username:      "testuser",
-			archiveServer: "testserver",
-			sourceFolder:  "/some/folder",
-			isNotFoundErr: false,
-			wantSshErr:    false,
-			wantOtherErr:  true,
-			errMsg:        "ssh transport failure",
+			name:         "other ssh failure",
+			wantOtherErr: true,
+			errMsg:       "ssh transport failure",
 		},
-		// Add more test cases here.
 	}
 
+	oldGoos := goos
 	oldNewDumbClient := newDumbClient
 	oldCheckRemoteDirectory := checkRemoteDirectory
-	oldIsRemoteDirectoryNotFound := isRemoteDirectoryNotFound
-	defer func() {
+	oldIsRemoteDirectoryNotFoundSsh := isRemoteDirectoryNotFoundSsh
+	t.Cleanup(func() {
+		goos = oldGoos
 		newDumbClient = oldNewDumbClient
 		checkRemoteDirectory = oldCheckRemoteDirectory
-		isRemoteDirectoryNotFound = oldIsRemoteDirectoryNotFound
-	}()
+		isRemoteDirectoryNotFoundSsh = oldIsRemoteDirectoryNotFoundSsh
+	})
+	goos = "windows"
+	newDumbClient = func(username, password, server string) (*Client, error) {
+		return &Client{}, nil
+	}
 
 	for _, tt := range tests {
-		var returnError error
-		if tt.wantSshErr || tt.wantOtherErr {
-			returnError = errors.New(tt.errMsg)
-		}
-
-		newDumbClient = func(username, password, server string) (*Client, error) {
-			return &Client{}, nil
-		}
-		checkRemoteDirectory = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
-			return returnError
-		}
-		isRemoteDirectoryNotFound = func(err error) bool {
-			return tt.isNotFoundErr
-		}
-
 		t.Run(tt.name, func(t *testing.T) {
-			sshErr, otherErr := CheckDataCentrallyAvailableSsh(tt.username, tt.archiveServer, tt.sourceFolder, nil)
+			var returnError error
+			if tt.wantSshErr || tt.wantOtherErr {
+				returnError = errors.New(tt.errMsg)
+			}
+
+			checkRemoteDirectory = func(c *Client, sourceFolder string, sshOutput io.Writer) error {
+				return returnError
+			}
+			isRemoteDirectoryNotFoundSsh = func(err error) bool {
+				return tt.isNotFoundErr
+			}
+
+			sshErr, otherErr := CheckDataCentrallyAvailableSsh("testuser", "testserver", "/test/folder", nil)
 			if (sshErr != nil) != tt.wantSshErr {
-				t.Errorf("CheckDataCentrallyAvailable() sshErr = %v, wantSshErr %v", sshErr != nil, tt.wantSshErr)
+				t.Errorf("CheckDataCentrallyAvailableSsh() sshErr = %v, wantSshErr %v", sshErr, tt.wantSshErr)
 			}
 			if (otherErr != nil) != tt.wantOtherErr {
-				t.Errorf("CheckDataCentrallyAvailable() otherErr = %v, wantOtherErr %v", otherErr != nil, tt.wantOtherErr)
-			}
-			if sshErr != nil && tt.wantSshErr && sshErr.Error() != tt.errMsg {
-				t.Errorf("CheckDataCentrallyAvailable() errMsg = %v, wantErrMsg %v", sshErr.Error(), tt.errMsg)
-			}
-			if otherErr != nil && tt.wantOtherErr && otherErr.Error() != tt.errMsg {
-				t.Errorf("CheckDataCentrallyAvailable() otherErrMsg = %v, wantErrMsg %v", otherErr.Error(), tt.errMsg)
+				t.Errorf("CheckDataCentrallyAvailableSsh() otherErr = %v, wantOtherErr %v", otherErr, tt.wantOtherErr)
 			}
 		})
+	}
+}
+
+func TestCheckDataCentrallyAvailable_Windows_NewDumbClientError(t *testing.T) {
+	oldGoos := goos
+	oldNewDumbClient := newDumbClient
+	t.Cleanup(func() {
+		goos = oldGoos
+		newDumbClient = oldNewDumbClient
+	})
+	goos = "windows"
+	newDumbClient = func(username, password, server string) (*Client, error) {
+		return nil, errors.New("dial failure")
+	}
+
+	sshErr, otherErr := CheckDataCentrallyAvailableSsh("testuser", "testserver", "/test/folder", nil)
+	if sshErr != nil {
+		t.Errorf("expected no sshErr, got %v", sshErr)
+	}
+	if otherErr == nil {
+		t.Fatal("expected an error when the SSH client cannot be created, got nil")
 	}
 }


### PR DESCRIPTION
This is unsuitable given the specifics of kerberos auth that are not covered by the go client in linux (for example reading the ticket from cache)