### PR TITLE
feat: add landingzones from transfer type to job

### DIFF
--- a/cmd/commands/datasetArchiver.go
+++ b/cmd/commands/datasetArchiver.go
@@ -23,7 +23,10 @@ var datasetArchiverCmd = &cobra.Command{
 You must choose either an ownerGroup, in which case all archivable datasets
 of this ownerGroup not yet archived will be archived.
 Or you choose a (list of) datasetIds, in which case all archivable datasets
-of this list not yet archived will be archived. 
+of this list not yet archived will be archived.
+
+The transfer type used for the archival job's landing zone can be selected
+via the --transfer-type flag. Available options: "ssh", "globus", "rocrate".
 
 For further help see "` + cliutils.MANUAL + `"`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -48,6 +51,7 @@ For further help see "` + cliutils.MANUAL + `"`,
 		nonInteractiveFlag, _ := cmd.Flags().GetBool("noninteractive")
 		ownerGroup, _ := cmd.Flags().GetString("ownergroup")
 		showVersion, _ := cmd.Flags().GetBool("version")
+		transferType, _ := cmd.Flags().GetString("transfer-type")
 
 		if datasetUtils.TestFlags != nil {
 			datasetUtils.TestFlags(map[string]interface{}{
@@ -61,7 +65,9 @@ For further help see "` + cliutils.MANUAL + `"`,
 				"noninteractive": nonInteractiveFlag,
 				"version":        showVersion,
 				"ownergroup":     ownerGroup,
-				"execution-time": executionTimeStr})
+				"execution-time": executionTimeStr,
+				"transfer-type":  transferType,
+			})
 			return
 		}
 
@@ -125,9 +131,18 @@ For further help see "` + cliutils.MANUAL + `"`,
 			log.Fatalf("Okay the archive process is stopped here, no datasets will be archived\n")
 		}
 
+		convertedTransferType, err := datasetUtils.ConvertToTransferType(transferType)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		log.Printf("You chose to archive the new datasets\n")
 		log.Printf("Submitting Archive Job for the ingested datasets.\n")
-		jobId, err := datasetUtils.CreateArchivalJob(client, APIServer, user, resolvedOwnerGroup, archivableDatasets, &tapecopies, executionTime)
+		jobId, err := datasetUtils.CreateArchivalJob(client, APIServer, user, resolvedOwnerGroup, archivableDatasets, datasetUtils.ArchivalJobOptions{
+			TapeCopies:    &tapecopies,
+			TransferType:  &convertedTransferType,
+			ExecutionTime: executionTime,
+		})
 		if err != nil {
 			log.Fatalf("Couldn't create a job: %s\n", err.Error())
 		}
@@ -145,6 +160,7 @@ func init() {
 	datasetArchiverCmd.Flags().Bool("devenv", false, "Use development environment instead or production")
 	datasetArchiverCmd.Flags().Bool("noninteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
 	datasetArchiverCmd.Flags().String("ownergroup", "", "Specifies to which owner group should the archival job belong. If no dataset id's are passed, all datasets belonging to this ownergroup that can also be marked as archivable will be included. If not specified, a list of dataset id's must be passed as arguments instead")
+	datasetArchiverCmd.Flags().String("transfer-type", "ssh", "Selects the transfer type to be used for transferring files. Available options: \"ssh\", \"globus\", \"rocrate\"")
 
 	datasetArchiverCmd.MarkFlagsMutuallyExclusive("testenv", "localenv", "devenv")
 }

--- a/cmd/commands/datasetArchiver.go
+++ b/cmd/commands/datasetArchiver.go
@@ -26,7 +26,7 @@ Or you choose a (list of) datasetIds, in which case all archivable datasets
 of this list not yet archived will be archived.
 
 The transfer type used for the archival job's landing zone can be selected
-via the --transfer-type flag. Available options: "ssh", "globus", "rocrate".
+via the --transfer-type flag. Available options: "ssh", "globus", "s3", "rocrate".
 
 For further help see "` + cliutils.MANUAL + `"`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -160,7 +160,7 @@ func init() {
 	datasetArchiverCmd.Flags().Bool("devenv", false, "Use development environment instead or production")
 	datasetArchiverCmd.Flags().Bool("noninteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
 	datasetArchiverCmd.Flags().String("ownergroup", "", "Specifies to which owner group should the archival job belong. If no dataset id's are passed, all datasets belonging to this ownergroup that can also be marked as archivable will be included. If not specified, a list of dataset id's must be passed as arguments instead")
-	datasetArchiverCmd.Flags().String("transfer-type", "ssh", "Selects the transfer type to be used for transferring files. Available options: \"ssh\", \"globus\", \"rocrate\"")
+	datasetArchiverCmd.Flags().String("transfer-type", "ssh", "Selects the transfer type to be used for transferring files. Available options: \"ssh\", \"globus\", \"s3\", \"rocrate\"")
 
 	datasetArchiverCmd.MarkFlagsMutuallyExclusive("testenv", "localenv", "devenv")
 }

--- a/cmd/commands/datasetIngestor.go
+++ b/cmd/commands/datasetIngestor.go
@@ -92,7 +92,7 @@ For Windows you need instead to specify -user username:password on the command l
 		// TODO: read in CFG!
 
 		// transfer type
-		transferType, err := cliutils.ConvertToTransferType(transferTypeFlag)
+		transferType, err := datasetUtils.ConvertToTransferType(transferTypeFlag)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -105,9 +105,9 @@ For Windows you need instead to specify -user username:password on the command l
 		skipSymlinks := ""
 
 		switch transferType {
-		case cliutils.Ssh:
+		case datasetUtils.Ssh:
 			transferFiles = cliutils.SshTransfer
-		case cliutils.Globus:
+		case datasetUtils.Globus:
 			transferFiles = cliutils.GlobusTransfer
 			var globusConfigPath string
 			if cmd.Flags().Lookup("globus-cfg").Changed {
@@ -128,7 +128,7 @@ For Windows you need instead to specify -user username:password on the command l
 			if autoarchiveFlag {
 				log.Fatalln("Cannot autoarchive when transferring via Globus due to the transfer happening asynchronously. Use the \"globusCheckTransfer\" command to archive them")
 			}
-		case cliutils.S3:
+		case datasetUtils.S3:
 			transferFiles = cliutils.TransferFilesS3
 
 			if cmd.Flags().Changed("linkfiles") && linkfiles != "delete" {
@@ -136,6 +136,8 @@ For Windows you need instead to specify -user username:password on the command l
 			}
 			log.Println("WARNING: transfer-type is s3: symbolic links will be dropped from ingestion and copying")
 			skipSymlinks = "sA"
+		default:
+			log.Fatalf("unsupported transfer type for datasetIngestor: %q. Available options: \"ssh\", \"globus\", \"s3\"\n", transferTypeFlag)
 		}
 
 		if datasetUtils.TestFlags != nil {
@@ -498,7 +500,10 @@ For Windows you need instead to specify -user username:password on the command l
 			log.Printf("Submitting Archive Job for the ingested datasets.\n")
 			// TODO: change param type from pointer to regular as it is unnecessary
 			//   for it to be passed as pointer
-			jobId, err := datasetUtils.CreateArchivalJob(client, APIServer, user, archivableDatasetListOwnerGroup, archivableDatasetList, &tapecopies, nil)
+			jobId, err := datasetUtils.CreateArchivalJob(client, APIServer, user, archivableDatasetListOwnerGroup, archivableDatasetList, datasetUtils.ArchivalJobOptions{
+				TapeCopies:   &tapecopies,
+				TransferType: &transferType,
+			})
 
 			if err != nil {
 				color.Set(color.FgRed)

--- a/cmd/commands/globusCheckTransfer.go
+++ b/cmd/commands/globusCheckTransfer.go
@@ -188,7 +188,7 @@ func globusCheckTransferCreateArchiveJobs(client *http.Client, APIServer string,
 	log.Printf("Submitting Archive Job for archivable datasets.\n")
 	// TODO: change param type from pointer to regular as it is unnecessary
 	//   for it to be passed as pointer
-	jobIds, errs := datasetUtils.CreateArchivalJobs(client, APIServer, user, archivableDatasetMap, &tapecopies)
+	jobIds, errs := datasetUtils.CreateArchivalJobs(client, APIServer, user, archivableDatasetMap, datasetUtils.ArchivalJobOptions{TapeCopies: &tapecopies})
 
 	color.Set(color.FgRed)
 	for _, err := range errs {

--- a/datasetUtils/createJob.go
+++ b/datasetUtils/createJob.go
@@ -13,8 +13,19 @@ type Job struct {
 	Id string `json:"id"`
 }
 
+type LandingZoneEntry struct {
+	Type TransferType `json:"type"`
+}
+
+// ArchivalJobOptions bundles the optional parameters of an archival job.
+type ArchivalJobOptions struct {
+	TapeCopies    *int
+	TransferType  *TransferType
+	ExecutionTime *time.Time
+}
+
 /*
-`CreateArchivalJob` creates a new job on the server. It takes in an HTTP client, the API server URL, a user map, a list of datasets, and a pointer to an integer representing the number of tape copies.
+`CreateArchivalJob` creates a new job on the server. It takes in an HTTP client, the API server URL, a user map, a list of datasets, and a set of job options.
 
 The function constructs a job map with various parameters, including the email of the job initiator, the type of job, the creation time, the job parameters, and the job status message. It also includes a list of datasets.
 
@@ -27,12 +38,12 @@ Parameters:
 - APIServer: A string representing the API server URL
 - user: A map with string keys and values representing user information
 - datasetMap: A list of datasets grouped by ownerGroups
-- tapecopies: A pointer to an integer representing the number of tape copies
+- opts: The archival job's optional parameters (tape copies, transfer type, execution time)
 
 Returns:
 - jobId: A string representing the job ID if the job was successfully created, or an empty string otherwise
 */
-func CreateArchivalJob(client *http.Client, APIServer string, user map[string]string, ownerGroup string, datasetList []string, tapecopies *int, executionTime *time.Time) (jobId string, err error) {
+func CreateArchivalJob(client *http.Client, APIServer string, user map[string]string, ownerGroup string, datasetList []string, opts ArchivalJobOptions) (jobId string, err error) {
 	// important: define field with capital names and rename fields via 'json' constructs
 	// otherwise the marshaling will omit the fields !
 
@@ -42,9 +53,17 @@ func CreateArchivalJob(client *http.Client, APIServer string, user map[string]st
 	}
 
 	type jobParamsStruct struct {
-		TapeCopies string `json:"tapeCopies"`
-		Username   string `json:"username"`
-		OwnerGroup string `json:"ownerGroup"`
+		TapeCopies  string                      `json:"tapeCopies"`
+		Username    string                      `json:"username"`
+		OwnerGroup  string                      `json:"ownerGroup"`
+		LandingZone map[string]LandingZoneEntry `json:"landingZone,omitempty"`
+	}
+
+	jobParams := jobParamsStruct{
+		TapeCopies:  "one",
+		Username:    user["username"],
+		OwnerGroup:  ownerGroup,
+		LandingZone: make(map[string]LandingZoneEntry),
 	}
 
 	type createJobDto struct {
@@ -62,29 +81,27 @@ func CreateArchivalJob(client *http.Client, APIServer string, user map[string]st
 
 	//jobMap["creationTime"] = time.Now().Format(time.RFC3339)
 	// TODO these job parameters may become obsolete
-	tc := "one"
-	if *tapecopies == 2 {
-		tc = "two"
+	if *opts.TapeCopies == 2 {
+		jobParams.TapeCopies = "two"
 	}
 
 	emptyfiles := []string{}
 	dsMap := make([]datasetStruct, len(datasetList))
 	for i, dataset := range datasetList {
 		dsMap[i] = datasetStruct{dataset, emptyfiles}
+		if opts.TransferType != nil {
+			jobParams.LandingZone[dataset] = LandingZoneEntry{Type: *opts.TransferType}
+		}
 	}
 
 	// jobMap["datasetList"] = dsMap
 	createJob := createJobDto{
-		JobType: "archive",
-		JobParams: jobParamsStruct{
-			TapeCopies: tc,
-			Username:   user["username"],
-			OwnerGroup: ownerGroup,
-		},
+		JobType:          "archive",
+		JobParams:        jobParams,
 		JobStatusMessage: "jobSubmitted",
 		DatasetList:      dsMap,
 		ContactEmail:     user["mail"],
-		ExecutionTime:    executionTime,
+		ExecutionTime:    opts.ExecutionTime,
 	}
 
 	// marshal to JSON
@@ -125,12 +142,12 @@ func CreateArchivalJob(client *http.Client, APIServer string, user map[string]st
 }
 
 // Auxiliary function to CreateArchivalJob when you need to use a list of datasets grouped by ownerGroups
-func CreateArchivalJobs(client *http.Client, APIServer string, user map[string]string, groupedDatasetLists map[string][]string, tapecopies *int) (jobIds []string, errs []error) {
+func CreateArchivalJobs(client *http.Client, APIServer string, user map[string]string, groupedDatasetLists map[string][]string, opts ArchivalJobOptions) (jobIds []string, errs []error) {
 	jobIds = make([]string, len(groupedDatasetLists))
 	errs = make([]error, len(groupedDatasetLists))
 	i := 0
 	for group := range groupedDatasetLists {
-		jobIds[i], errs[i] = CreateArchivalJob(client, APIServer, user, group, groupedDatasetLists[group], tapecopies, nil)
+		jobIds[i], errs[i] = CreateArchivalJob(client, APIServer, user, group, groupedDatasetLists[group], opts)
 		i++
 	}
 	return jobIds, errs

--- a/datasetUtils/createJob_test.go
+++ b/datasetUtils/createJob_test.go
@@ -42,7 +42,7 @@ func TestCreateJob(t *testing.T) {
 		*tapecopies = 1
 
 		// Call the function
-		jobId, err := CreateArchivalJob(client, APIServer, user, "group1", datasetList, tapecopies, nil)
+		jobId, err := CreateArchivalJob(client, APIServer, user, "group1", datasetList, ArchivalJobOptions{TapeCopies: tapecopies})
 		if err != nil {
 			t.Errorf("Unexpected error received: %v", err)
 		}
@@ -75,7 +75,7 @@ func TestCreateJob(t *testing.T) {
 		*tapecopies = 1
 
 		// Call the function
-		jobId, err := CreateArchivalJob(client, APIServer, user, "group1", datasetList, tapecopies, nil)
+		jobId, err := CreateArchivalJob(client, APIServer, user, "group1", datasetList, ArchivalJobOptions{TapeCopies: tapecopies})
 		if err == nil {
 			t.Errorf("Expected an error to be returned from CreateJob")
 		}
@@ -113,7 +113,7 @@ func TestCreateJob(t *testing.T) {
 		*tapecopies = 1
 
 		// Call the function
-		jobId, err := CreateArchivalJob(client, APIServer, user, "group1", datasetList, tapecopies, nil)
+		jobId, err := CreateArchivalJob(client, APIServer, user, "group1", datasetList, ArchivalJobOptions{TapeCopies: tapecopies})
 
 		if err == nil {
 			t.Error("Expected an error to be returned from CreateJob")
@@ -196,7 +196,7 @@ func TestCreateJob(t *testing.T) {
 		}
 
 		// Call the function with the mock client
-		jobId, err := CreateArchivalJob(client, server.URL, user, "group1", datasetList, tapecopies, nil)
+		jobId, err := CreateArchivalJob(client, server.URL, user, "group1", datasetList, ArchivalJobOptions{TapeCopies: tapecopies})
 		if err != nil {
 			t.Errorf("Got an error when creating a job: %s", err.Error())
 		}
@@ -299,7 +299,7 @@ func TestCreateArchivalJobs(t *testing.T) {
 		tapecopies := new(int)
 		*tapecopies = 1
 
-		jobIds, errs := CreateArchivalJobs(client, server.URL, user, groupedDatasets, tapecopies)
+		jobIds, errs := CreateArchivalJobs(client, server.URL, user, groupedDatasets, ArchivalJobOptions{TapeCopies: tapecopies})
 
 		if len(jobIds) != 2 {
 			t.Errorf("Expected 2 job IDs, got %d", len(jobIds))
@@ -345,7 +345,7 @@ func TestCreateArchivalJobs(t *testing.T) {
 		tapecopies := new(int)
 		*tapecopies = 1
 
-		_, errs := CreateArchivalJobs(client, server.URL, user, groupedDatasets, tapecopies)
+		_, errs := CreateArchivalJobs(client, server.URL, user, groupedDatasets, ArchivalJobOptions{TapeCopies: tapecopies})
 
 		if len(errs) == 0 {
 			t.Error("Expected at least one error")

--- a/datasetUtils/transferType.go
+++ b/datasetUtils/transferType.go
@@ -1,6 +1,7 @@
-package cliutils
+package datasetUtils
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -11,6 +12,7 @@ const (
 	Ssh TransferType = iota
 	Globus
 	S3
+	Rocrate
 )
 
 func ConvertToTransferType(input string) (TransferType, error) {
@@ -22,6 +24,26 @@ func ConvertToTransferType(input string) (TransferType, error) {
 		return Globus, nil
 	case "s3":
 		return S3, nil
+	case "rocrate":
+		return Rocrate, nil
 	}
 	return Ssh, fmt.Errorf("invalid transfer type was given: %s", input)
+}
+
+func (t TransferType) String() string {
+	switch t {
+	case Ssh:
+		return "ssh"
+	case Globus:
+		return "globus"
+	case S3:
+		return "s3"
+	case Rocrate:
+		return "rocrate"
+	}
+	return ""
+}
+
+func (t TransferType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }

--- a/datasetUtils/transferType_test.go
+++ b/datasetUtils/transferType_test.go
@@ -1,4 +1,4 @@
-package cliutils
+package datasetUtils
 
 import "testing"
 


### PR DESCRIPTION
Extend transer-types to datasetArchiver, including the type rocrate and add them as landingZones to jobParams