### PR TITLE
feat: add mark for deletion workflow

### DIFF
--- a/cmd/commands/datasetMarkForDeletion.go
+++ b/cmd/commands/datasetMarkForDeletion.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/cmd/cliutils"
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+	"github.com/paulscherrerinstitute/scicat-cli/v3/orchestrator"
+	"github.com/spf13/cobra"
+)
+
+var datasetMarkForDeletionCmd = &cobra.Command{
+	Use:   "datasetMarkForDeletion [options] datasetPid",
+	Short: "Flag a dataset's archived data for deletion",
+	Long: `Tool to flag a dataset's archived data for deletion.
+
+If Datablock entries exist for a given dataset, a markForDeletion job will be launched, carrying
+the given deletion code and reason. This does not remove anything from the archive system or the
+data catalog itself - it only records the request.
+
+Unlike datasetCleaner, this command is available to any authenticated user and never touches the
+data catalog.
+
+For further help see "` + cliutils.MANUAL + `"`,
+	Args: exactArgsWithVersionException(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// vars & consts
+		var client = &http.Client{
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: false}},
+			Timeout:   10 * time.Second}
+
+		const CMD = "datasetMarkForDeletion"
+
+		// pass parameters
+		deletionCodeFlag := cliutils.GetCobraStringFlag(cmd, "deletionCode")
+		deletionReasonFlag := cliutils.GetCobraStringFlag(cmd, "deletionReason")
+		nonInteractiveFlag := cliutils.GetCobraBoolFlag(cmd, "nonInteractive")
+		testenvFlag := cliutils.GetCobraBoolFlag(cmd, "testenv")
+		devenvFlag := cliutils.GetCobraBoolFlag(cmd, "devenv")
+		scicatUrl := cliutils.GetCobraStringFlag(cmd, "scicat-url")
+		userpass := cliutils.GetCobraStringFlag(cmd, "user")
+		token := cliutils.GetCobraStringFlag(cmd, "token")
+		oidc := cliutils.GetCobraBoolFlag(cmd, "oidc")
+		showVersion := cliutils.GetCobraBoolFlag(cmd, "version")
+
+		if datasetUtils.TestFlags != nil {
+			datasetUtils.TestFlags(map[string]interface{}{
+				"user":           userpass,
+				"token":          token,
+				"testenv":        testenvFlag,
+				"devenv":         devenvFlag,
+				"scicat-url":     scicatUrl,
+				"nonInteractive": nonInteractiveFlag,
+				"deletionCode":   deletionCodeFlag,
+				"deletionReason": deletionReasonFlag,
+				"version":        showVersion,
+			})
+			return
+		}
+
+		// execute command
+		if showVersion {
+			fmt.Printf("%s\n", VERSION)
+			return
+		}
+
+		// check for program version only if running interactively
+
+		datasetUtils.CheckForNewVersion(client, CMD, VERSION)
+		datasetUtils.CheckForServiceAvailability(client, testenvFlag, true)
+
+		// configure environment
+		config := cliutils.InputEnvironmentConfig{
+			TestenvFlag: testenvFlag,
+			DevenvFlag:  devenvFlag,
+			ScicatUrl:   scicatUrl,
+		}
+		APIServer := config.ResolveAPIServer()
+
+		if len(args) != 1 {
+			log.Println("invalid number of args")
+			return
+		}
+		pid := args[0]
+
+		user, _, err := cliutils.Authenticate(cliutils.RealAuthenticator{}, client, APIServer, userpass, token, oidc)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = orchestrator.MarkDatasetForDeletion(client, APIServer, user, pid, nonInteractiveFlag, datasetUtils.RemovalJobOptions{
+			DeletionCode:   deletionCodeFlag,
+			DeletionReason: deletionReasonFlag,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(datasetMarkForDeletionCmd)
+
+	datasetMarkForDeletionCmd.Flags().String("deletionCode", "", "Code for the deletion reason, recorded on the markForDeletion job")
+	datasetMarkForDeletionCmd.Flags().String("deletionReason", "", "Reason for the deletion, recorded on the markForDeletion job")
+	datasetMarkForDeletionCmd.Flags().Bool("nonInteractive", false, "Defines if no questions will be asked, just do it - make sure you know what you are doing")
+	datasetMarkForDeletionCmd.Flags().Bool("testenv", false, "Use test environment (qa) instead of production environment")
+	datasetMarkForDeletionCmd.Flags().Bool("devenv", false, "Use development environment instead of production environment (developers only)")
+
+	datasetMarkForDeletionCmd.MarkFlagsMutuallyExclusive("testenv", "devenv")
+}

--- a/datasetUtils/removeFromArchive.go
+++ b/datasetUtils/removeFromArchive.go
@@ -29,18 +29,23 @@ type jobParamsStruct struct {
 	DeletionReason string `json:"deletionReason,omitempty"`
 }
 
-// RemovalJobOptions bundles the optional parameters of a reset job.
+// RemovalJobOptions bundles the optional parameters of a removal job.
 type RemovalJobOptions struct {
 	DeletionCode   string
 	DeletionReason string
 }
 
+const (
+	JobTypeReset           = "reset"
+	JobTypeMarkForDeletion = "markForDeletion"
+)
+
 type JobSubmissionResponse struct {
-	ID string `json:"id"`
+	ID               string `json:"id"`
 	JobStatusMessage string `json:"jobStatusMessage"`
 }
 
-func RemoveFromArchive(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, opts RemovalJobOptions) (string, error) {
+func RemoveFromArchive(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, jobType string, opts RemovalJobOptions) (string, error) {
 	respObj, err := getDatablocks(client, APIServer, pid, user)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch datablocks: %w", err)
@@ -57,8 +62,8 @@ func RemoveFromArchive(client *http.Client, APIServer string, pid string, user m
 	for _, item := range respObj {
 		log.Printf("ID: %s, Size: %d", item.ID, item.Size)
 	}
-	// Set up reset job
-	log.Println("Setting up reset job to remove dataset inside archive system")
+	// Set up removal job
+	log.Printf("Setting up %s job for dataset inside archive system", jobType)
 	if !nonInteractive {
 		color.Set(color.FgYellow)
 		log.Println("Are you sure? This action cannot be undone! Type 'y' to continue:")
@@ -71,10 +76,10 @@ func RemoveFromArchive(client *http.Client, APIServer string, pid string, user m
 	} else {
 		log.Println("Non-interactive mode: proceeding automatically.")
 	}
-	jobMap := buildResetJobMap(pid, user, opts)
+	jobMap := buildRemovalJobMap(pid, user, jobType, opts)
 	jobID, err := submitJob(client, APIServer, user, jobMap)
 	if err != nil {
-		return "", fmt.Errorf("archive reset job submission failed: %w", err)
+		return "", fmt.Errorf("%s job submission failed: %w", jobType, err)
 	}
 
 	return jobID, nil
@@ -109,10 +114,10 @@ func getDatablocks(client *http.Client, APIServer string, pid string, user map[s
 	return respObj, nil
 }
 
-func buildResetJobMap(pid string, user map[string]string, opts RemovalJobOptions) map[string]interface{} {
+func buildRemovalJobMap(pid string, user map[string]string, jobType string, opts RemovalJobOptions) map[string]interface{} {
 	return map[string]interface{}{
 		"emailJobInitiator": user["mail"],
-		"type":              "reset",
+		"type":              jobType,
 		"creationTime":      time.Now().Format(time.RFC3339),
 		"jobParams": jobParamsStruct{
 			Username:       user["username"],

--- a/datasetUtils/removeFromArchive_test.go
+++ b/datasetUtils/removeFromArchive_test.go
@@ -30,6 +30,7 @@ func TestRemoveFromArchive(t *testing.T) {
 		expectedDataset []map[string]interface{}
 		expectedJobID   string
 		expectPost      bool
+		jobType         string
 		deletionCode    string
 		deletionReason  string
 	}{
@@ -39,6 +40,7 @@ func TestRemoveFromArchive(t *testing.T) {
 			expectedDataset: []map[string]interface{}{},
 			expectedJobID:   "",
 			expectPost:      false,
+			jobType:         JobTypeReset,
 		},
 		{
 			name:         "Return datablocks list of size 2",
@@ -48,6 +50,7 @@ func TestRemoveFromArchive(t *testing.T) {
 			},
 			expectedJobID: "123",
 			expectPost:    true,
+			jobType:       JobTypeReset,
 		},
 		{
 			name:         "Includes deletion code and reason in the job params",
@@ -57,8 +60,21 @@ func TestRemoveFromArchive(t *testing.T) {
 			},
 			expectedJobID:  "123",
 			expectPost:     true,
+			jobType:        JobTypeReset,
 			deletionCode:   "SUPERSEDED",
 			deletionReason: "replaced by a newer dataset",
+		},
+		{
+			name:         "Submits a markForDeletion job type",
+			mockResponse: `[{"id": "datablock1", "size": 50}]`,
+			expectedDataset: []map[string]interface{}{
+				{"pid": "dataset1", "files": []interface{}{}},
+			},
+			expectedJobID:  "123",
+			expectPost:     true,
+			jobType:        JobTypeMarkForDeletion,
+			deletionCode:   "EXPIRED",
+			deletionReason: "retention elapsed",
 		},
 	}
 	user := map[string]string{
@@ -78,7 +94,7 @@ func TestRemoveFromArchive(t *testing.T) {
 				},
 				JobStatusMessage: "jobSubmitted",
 				DatasetList:      tt.expectedDataset,
-				Type:             "reset",
+				Type:             tt.jobType,
 			}
 
 			// Create a mock HTTP client
@@ -122,7 +138,7 @@ func TestRemoveFromArchive(t *testing.T) {
 				},
 			}
 
-			jobID, err := RemoveFromArchive(client, "http://mockserver", "dataset1", user, true, RemovalJobOptions{
+			jobID, err := RemoveFromArchive(client, "http://mockserver", "dataset1", user, true, tt.jobType, RemovalJobOptions{
 				DeletionCode:   tt.deletionCode,
 				DeletionReason: tt.deletionReason,
 			})

--- a/orchestrator/datasetCleaner.go
+++ b/orchestrator/datasetCleaner.go
@@ -25,9 +25,8 @@ func CleanDataset(client *http.Client, APIServer string, user map[string]string,
 		return err
 	}
 
-	jobID, err := removeFromArchiveFunc(client, APIServer, pid, user, nonInteractive, opts)
+	jobID, err := submitRemovalJob(client, APIServer, user, pid, nonInteractive, datasetUtils.JobTypeReset, opts)
 	if err != nil {
-		failJob(client, APIServer, user, jobID)
 		return err
 	}
 
@@ -42,6 +41,17 @@ func CleanDataset(client *http.Client, APIServer string, user map[string]string,
 	}
 
 	return nil
+}
+
+// submitRemovalJob launches a removal job of jobType for pid and returns its ID. On failure, the
+// job (if one was created) is best-effort patched to a failed status before the error is returned.
+func submitRemovalJob(client *http.Client, APIServer string, user map[string]string, pid string, nonInteractive bool, jobType string, opts datasetUtils.RemovalJobOptions) (string, error) {
+	jobID, err := removeFromArchiveFunc(client, APIServer, pid, user, nonInteractive, jobType, opts)
+	if err != nil {
+		failJob(client, APIServer, user, jobID)
+		return "", err
+	}
+	return jobID, nil
 }
 
 // failJob best-effort patches jobID to a failed status; jobID is empty when no job was ever

--- a/orchestrator/datasetCleaner_test.go
+++ b/orchestrator/datasetCleaner_test.go
@@ -22,7 +22,7 @@ func withCleanDatasetMocks(t *testing.T) {
 		patchJobStatusFunc = oldPatchJobStatus
 	})
 
-	removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, opts datasetUtils.RemovalJobOptions) (string, error) {
+	removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, jobType string, opts datasetUtils.RemovalJobOptions) (string, error) {
 		return "job1", nil
 	}
 	removeFromCatalogFunc = func(client *http.Client, APIServer string, pid string, jobID string, user map[string]string, nonInteractive bool) error {
@@ -76,10 +76,12 @@ func TestCleanDataset(t *testing.T) {
 		}
 	})
 
-	t.Run("passes the deletion code and reason through to the archive removal", func(t *testing.T) {
+	t.Run("submits a reset job carrying the deletion code and reason", func(t *testing.T) {
 		withCleanDatasetMocks(t)
+		var gotJobType string
 		var gotOpts datasetUtils.RemovalJobOptions
-		removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, opts datasetUtils.RemovalJobOptions) (string, error) {
+		removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, jobType string, opts datasetUtils.RemovalJobOptions) (string, error) {
+			gotJobType = jobType
 			gotOpts = opts
 			return "job1", nil
 		}
@@ -88,6 +90,9 @@ func TestCleanDataset(t *testing.T) {
 		if err := CleanDataset(nil, "", archiveManager, "testPid", true, false, wantOpts); err != nil {
 			t.Fatalf("expected no error, got: %v", err)
 		}
+		if gotJobType != datasetUtils.JobTypeReset {
+			t.Errorf("jobType = %q, want %q", gotJobType, datasetUtils.JobTypeReset)
+		}
 		if gotOpts != wantOpts {
 			t.Errorf("RemovalJobOptions = %+v, want %+v", gotOpts, wantOpts)
 		}
@@ -95,7 +100,7 @@ func TestCleanDataset(t *testing.T) {
 
 	t.Run("patches the job to failed and returns the error when archive removal fails", func(t *testing.T) {
 		withCleanDatasetMocks(t)
-		removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, opts datasetUtils.RemovalJobOptions) (string, error) {
+		removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, jobType string, opts datasetUtils.RemovalJobOptions) (string, error) {
 			return "job1", errors.New("boom")
 		}
 		var patchedJobID, patchedStatus string
@@ -116,7 +121,7 @@ func TestCleanDataset(t *testing.T) {
 
 	t.Run("does not patch the job when archive removal fails without creating one", func(t *testing.T) {
 		withCleanDatasetMocks(t)
-		removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, opts datasetUtils.RemovalJobOptions) (string, error) {
+		removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, jobType string, opts datasetUtils.RemovalJobOptions) (string, error) {
 			return "", errors.New("boom")
 		}
 		var patchCalled bool

--- a/orchestrator/markForDeletion.go
+++ b/orchestrator/markForDeletion.go
@@ -1,0 +1,19 @@
+package orchestrator
+
+import (
+	"net/http"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+)
+
+/*
+MarkDatasetForDeletion flags a dataset's archived data for deletion by launching a
+markForDeletion job carrying a deletion code and reason.
+
+Unlike CleanDataset, it is open to any authenticated user and never touches the data catalog -
+it only records the request against the archive system.
+*/
+func MarkDatasetForDeletion(client *http.Client, APIServer string, user map[string]string, pid string, nonInteractive bool, opts datasetUtils.RemovalJobOptions) error {
+	_, err := submitRemovalJob(client, APIServer, user, pid, nonInteractive, datasetUtils.JobTypeMarkForDeletion, opts)
+	return err
+}

--- a/orchestrator/markForDeletion_test.go
+++ b/orchestrator/markForDeletion_test.go
@@ -1,0 +1,80 @@
+package orchestrator
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
+)
+
+func TestMarkDatasetForDeletion(t *testing.T) {
+	anyUser := map[string]string{"username": "someoneElse", "accessToken": "testToken"}
+
+	t.Run("is allowed for a non archiveManager user", func(t *testing.T) {
+		withCleanDatasetMocks(t)
+
+		if err := MarkDatasetForDeletion(nil, "", anyUser, "testPid", true, datasetUtils.RemovalJobOptions{}); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("submits a markForDeletion job carrying the deletion code and reason", func(t *testing.T) {
+		withCleanDatasetMocks(t)
+		var gotJobType string
+		var gotOpts datasetUtils.RemovalJobOptions
+		removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, jobType string, opts datasetUtils.RemovalJobOptions) (string, error) {
+			gotJobType = jobType
+			gotOpts = opts
+			return "job1", nil
+		}
+		wantOpts := datasetUtils.RemovalJobOptions{DeletionCode: "EXPIRED", DeletionReason: "retention elapsed"}
+
+		if err := MarkDatasetForDeletion(nil, "", anyUser, "testPid", true, wantOpts); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if gotJobType != datasetUtils.JobTypeMarkForDeletion {
+			t.Errorf("jobType = %q, want %q", gotJobType, datasetUtils.JobTypeMarkForDeletion)
+		}
+		if gotOpts != wantOpts {
+			t.Errorf("RemovalJobOptions = %+v, want %+v", gotOpts, wantOpts)
+		}
+	})
+
+	t.Run("never touches the data catalog", func(t *testing.T) {
+		withCleanDatasetMocks(t)
+		var catalogCalled bool
+		removeFromCatalogFunc = func(client *http.Client, APIServer string, pid string, jobID string, user map[string]string, nonInteractive bool) error {
+			catalogCalled = true
+			return nil
+		}
+
+		if err := MarkDatasetForDeletion(nil, "", anyUser, "testPid", true, datasetUtils.RemovalJobOptions{}); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if catalogCalled {
+			t.Error("expected the catalog never to be touched")
+		}
+	})
+
+	t.Run("patches the job to failed and returns the error when job submission fails", func(t *testing.T) {
+		withCleanDatasetMocks(t)
+		removeFromArchiveFunc = func(client *http.Client, APIServer string, pid string, user map[string]string, nonInteractive bool, jobType string, opts datasetUtils.RemovalJobOptions) (string, error) {
+			return "job1", errors.New("boom")
+		}
+		var patchedJobID, patchedStatus string
+		patchJobStatusFunc = func(client *http.Client, APIServer string, user map[string]string, jobID string, status string) error {
+			patchedJobID = jobID
+			patchedStatus = status
+			return nil
+		}
+
+		err := MarkDatasetForDeletion(nil, "", anyUser, "testPid", true, datasetUtils.RemovalJobOptions{})
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if patchedJobID != "job1" || patchedStatus != string(datasetUtils.JobFailed) {
+			t.Errorf("expected job1 to be patched to %q, got job %q status %q", datasetUtils.JobFailed, patchedJobID, patchedStatus)
+		}
+	})
+}


### PR DESCRIPTION
Add command for additional job type, mark for deletion. this is a bit experimental in the sense that the plan is for the job in scicat to only update the datasetlifecycle of the datasets. The advantage of using a job rather than doing the patch directly is if the job requires special permissions and the email is sent immediately on job submission